### PR TITLE
node_exporter: Support filesystems mounted under '/home'

### DIFF
--- a/roles/node_exporter/templates/node_exporter.service.j2
+++ b/roles/node_exporter/templates/node_exporter.service.j2
@@ -34,11 +34,11 @@ Restart=always
 RestartSec=1
 StartLimitInterval=0
 
-{% for m in ansible_mounts if m.mount == '/home' %}
-ProtectHome=read-only
-{% else %}
-ProtectHome=yes
+{% set protect_home = 'yes' %}
+{% for m in ansible_mounts if m.mount.startswith('/home') %}
+{%   set protect_home = 'read-only' %}
 {% endfor %}
+ProtectHome={{ protect_home }}
 NoNewPrivileges=yes
 
 {% if node_exporter_systemd_version | int >= 232 %}


### PR DESCRIPTION
Set systemd's ProtectHome to 'read-only' instead of 'yes' if there exists filesystems which are mounted at or under '/home', instead of at '/home' exclusively.

Fixes #13.

Signed-off-by: Kevin Bowrin <kevinbowrin@cunet.carleton.ca>