### PR TITLE
node-exporter: Fix download URL and default to v1.5.0

### DIFF
--- a/roles/node_exporter/README.md
+++ b/roles/node_exporter/README.md
@@ -22,7 +22,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
-| `node_exporter_version` | 1.1.2 | Node exporter package version. Also accepts latest as parameter. |
+| `node_exporter_version` | 1.5.0 | Node exporter package version. Also accepts latest as parameter. |
 | `node_exporter_binary_local_dir` | "" | Enables the use of local packages instead of those distributed on github. The parameter may be set to a directory where the `node_exporter` binary is stored on the host where ansible is run. This overrides the `node_exporter_version` parameter |
 | `node_exporter_web_listen_address` | "0.0.0.0:9100" | Address on which node exporter will listen |
 | `node_exporter_web_telemetry_path` | "/metrics" | Path under which to expose metrics |

--- a/roles/node_exporter/defaults/main.yml
+++ b/roles/node_exporter/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-node_exporter_version: 1.1.2
+node_exporter_version: 1.5.0
 node_exporter_binary_local_dir: ""
 node_exporter_web_listen_address: "0.0.0.0:9100"
 node_exporter_web_telemetry_path: "/metrics"

--- a/roles/node_exporter/tasks/install.yml
+++ b/roles/node_exporter/tasks/install.yml
@@ -24,8 +24,7 @@
     - name: Download node_exporter binary to local folder
       become: false
       ansible.builtin.get_url:
-        url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/
-              node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
+        url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
         dest: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
         checksum: "sha256:{{ node_exporter_checksum }}"
         mode: '0644'


### PR DESCRIPTION
Signed-off-by: Stevo Slavić <stevo.slavic@form3.tech>

Fixes https://github.com/prometheus-community/ansible/issues/15

Also bumps default node-exporter version to 1.5.0 for improved security (high CVE fixed) and kernel bug workaround (see [changelog](https://github.com/prometheus/node_exporter/releases/tag/v1.5.0)).