### PR TITLE
fix: Remove unnecessary dependency on jmespath

### DIFF
--- a/roles/prometheus/README.md
+++ b/roles/prometheus/README.md
@@ -13,7 +13,6 @@ When upgrading from <= 2.4.0 version of this role to >= 2.4.1 please turn off yo
 ## Requirements
 
 - Ansible >= 2.7 (It might work on previous versions, but we cannot guarantee it)
-- jmespath on deployer machine. If you are using Ansible from a Python virtualenv, install *jmespath* to the same virtualenv via pip.
 - gnu-tar on Mac deployer host (`brew install gnu-tar`)
 
 ## Role Variables

--- a/roles/prometheus/tasks/preflight.yml
+++ b/roles/prometheus/tasks/preflight.yml
@@ -52,7 +52,7 @@
 
 - name: Get all file_sd files from scrape_configs
   ansible.builtin.set_fact:
-    file_sd_files: "{{ prometheus_scrape_configs | json_query('[*][].file_sd_configs[*][].files[]') }}"
+    file_sd_files: "{{ prometheus_scrape_configs | selectattr('file_sd_configs', 'defined') | map(attribute='file_sd_configs') | flatten | map(attribute='files') | flatten }}"
 
 - name: Fail when file_sd targets are not defined in scrape_configs
   ansible.builtin.fail:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,5 @@
 molecule
 docker
 pytest-testinfra
-jmespath
 selinux
 passlib


### PR DESCRIPTION
This is straightforward manipulation to do with standard Jinja features, there's no need to use a non-default library.