### PR TITLE
docs: add argument specs to roles

### DIFF
--- a/roles/alertmanager/meta/argument_specs.yml
+++ b/roles/alertmanager/meta/argument_specs.yml
@@ -1,0 +1,98 @@
+---
+argument_specs:
+  main:
+    short_description: "Prometheus Alertmanager service"
+    description:
+      - "Deploy and manage Prometheus (alertmanager,https://github.com/prometheus/alertmanager) service using ansible."
+    author:
+      - "Prometheus Community"
+    options:
+      alertmanager_version:
+        description: "Alertmanager package version. Also accepts `latest` as parameter."
+        default: 0.21.0
+      alertmanager_binary_local_dir:
+        description:
+          - "Allows to use local packages instead of ones distributed on github."
+          - "As parameter it takes a directory where C(alertmanager) AND C(amtool) binaries are stored on host on which ansible is ran."
+          - "This overrides I(alertmanager_version) parameter"
+      alertmanager_web_listen_address:
+        description: "Address on which alertmanager will be listening"
+        default: "0.0.0.0:9093"
+      alertmanager_web_external_url:
+        description: "External address on which alertmanager is available. Useful when behind reverse proxy. Ex. example.org/alertmanager"
+        default: "http://localhost:9093/"
+      alertmanager_config_dir:
+        description: "Path to directory with alertmanager configuration"
+        default: "/etc/alertmanager"
+      alertmanager_db_dir:
+        description: "Path to directory with alertmanager database"
+        default: "/var/lib/alertmanager"
+      alertmanager_config_file:
+        description: "Variable used to provide custom alertmanager configuration file in form of ansible template"
+        default: "alertmanager.yml.j2"
+      alertmanager_config_flags_extra:
+        description: "Additional configuration flags passed to prometheus binary at startup"
+        type: "dict"
+      alertmanager_template_files:
+        description:
+          - 'List of folders where ansible will look for template files which will be copied to C("{{ alertmanager_config_dir }}/templates/").'
+          - "Files must have C(*.tmpl) extension"
+        type: "list"
+        default:
+          - "alertmanager/templates/*.tmpl"
+      alertmanager_resolve_timeout:
+        description: "Time after which an alert is declared resolved"
+        default: "3m"
+      alertmanager_smtp:
+        description: "SMTP (email) configuration"
+        type: "dict"
+      alertmanager_http_config:
+        description: "Http config for using custom webhooks"
+        type: "dict"
+      alertmanager_slack_api_url:
+        description: "Slack webhook url"
+      alertmanager_pagerduty_url:
+        description: "Pagerduty webhook url"
+      alertmanager_opsgenie_api_key:
+        description: "Opsgenie webhook key"
+      alertmanager_opsgenie_api_url:
+        description: "Opsgenie webhook url"
+      alertmanager_victorops_api_key:
+        description: "VictorOps webhook key"
+      alertmanager_victorops_api_url:
+        description: "VictorOps webhook url"
+      alertmanager_hipchat_api_url:
+        description: "Hipchat webhook url"
+      alertmanager_hipchat_auth_token:
+        description: "Hipchat authentication token"
+      alertmanager_wechat_url:
+        description: "Enterprise WeChat webhook url"
+      alertmanager_wechat_secret:
+        description: "Enterprise WeChat secret token"
+      alertmanager_wechat_corp_id:
+        description: "Enterprise WeChat corporation id"
+      alertmanager_cluster:
+        description:
+          - "HA cluster network configuration. Disabled by default."
+          - "More information in L(alertmanager readme,https://github.com/prometheus/alertmanager#high-availability)"
+        type: "dict"
+        default:
+          listen-address: ""
+      alertmanager_receivers:
+        description: "A list of notification receivers. Configuration same as in L(official docs,https://prometheus.io/docs/alerting/configuration/#<receiver>)"
+        type: "list"
+      alertmanager_inhibit_rules:
+        description: "List of inhibition rules. Same as in L(official docs,https://prometheus.io/docs/alerting/configuration/#inhibit_rule)"
+        type: "list"
+      alertmanager_route:
+        description: "Alert routing. More in L(official docs,https://prometheus.io/docs/alerting/configuration/#<route>)"
+        type: "dict"
+      alertmanager_amtool_config_file:
+        description: "Template for amtool config"
+        default: "amtool.yml.j2"
+      alertmanager_amtool_config_alertmanager_url:
+        description: "URL of the alertmanager"
+        default: "{{ alertmanager_web_external_url }}"
+      alertmanager_amtool_config_output:
+        description: 'Extended output, use C("") for simple output.'
+        default: "extended"

--- a/roles/blackbox_exporter/meta/argument_specs.yml
+++ b/roles/blackbox_exporter/meta/argument_specs.yml
@@ -1,0 +1,30 @@
+---
+argument_specs:
+  main:
+    short_description: "Deploy and manage Prometheus blackbox exporter"
+    description:
+      - "Deploy and manage Prometheus blackbox exporter which allows blackbox probing of endpoints over HTTP, HTTPS, DNS, TCP and ICMP."
+    author:
+      - "Prometheus Community"
+    options:
+      blackbox_exporter_version:
+        description: "Blackbox exporter package version"
+        default: "0.18.0"
+      blackbox_exporter_web_listen_address:
+        description: "Address on which blackbox exporter will be listening"
+        default: "0.0.0.0:9115"
+      blackbox_exporter_cli_flags:
+        description: "Additional configuration flags passed to blackbox exporter binary at startup"
+        type: "dict"
+        elements: "str"
+      blackbox_exporter_configuration_modules:
+        description: "Endpoints configuration"
+        type: "dict"
+        elements: "dict"
+        default:
+          http_2xx:
+            prober: http
+            timeout: 5s
+            http:
+              method: GET
+              valid_status_codes: []

--- a/roles/node_exporter/meta/argument_specs.yml
+++ b/roles/node_exporter/meta/argument_specs.yml
@@ -1,0 +1,60 @@
+---
+argument_specs:
+  main:
+    short_description: "Prometheus Node Exporter"
+    description:
+      - "Deploy prometheus L(node exporter,https://github.com/prometheus/node_exporter) using ansible"
+    author:
+      - "Prometheus Community"
+    options:
+      node_exporter_version:
+        description: "Node exporter package version. Also accepts latest as parameter."
+        default: "1.1.2"
+      node_exporter_binary_local_dir:
+        description:
+          - "Enables the use of local packages instead of those distributed on github."
+          - "The parameter may be set to a directory where the C(node_exporter) binary is stored on the host where ansible is run."
+          - "This overrides the I(node_exporter_version) parameter"
+      node_exporter_web_listen_address:
+        description: "Address on which node exporter will listen"
+        default: "0.0.0.0:9100"
+      node_exporter_web_telemetry_path:
+        description: "Path under which to expose metrics"
+        default: "/metrics"
+      node_exporter_enabled_collectors:
+        description:
+          - "List of dicts defining additionally enabled collectors and their configuration."
+          - "It adds collectors to L(those enabled by default,https://github.com/prometheus/node_exporter#enabled-by-default)."
+        type: "list"
+        default:
+          - systemd
+          - textfile:
+              directory: "{{ node_exporter_textfile_dir }}"
+      node_exporter_disabled_collectors:
+        description:
+          - "List of disabled collectors."
+          - "By default node_exporter disables collectors listed L(here,https://github.com/prometheus/node_exporter#disabled-by-default)."
+        type: "list"
+        elements: "str"
+      node_exporter_textfile_dir:
+        description:
+          - "Directory used by the L(Textfile Collector,https://github.com/prometheus/node_exporter#textfile-collector)."
+          - "To get permissions to write metrics in this directory, users must be in C(node-exp) system group."
+          - "B(Note:) More information in TROUBLESHOOTING.md guide."
+        default: "/var/lib/node_exporter"
+      node_exporter_tls_server_config:
+        description:
+          - "Configuration for TLS authentication."
+          - "Keys and values are the same as in L(node_exporter docs,https://github.com/prometheus/node_exporter/blob/master/https/README.md#sample-config)."
+        type: "dict"
+        elements: "str"
+      node_exporter_http_server_config:
+        description:
+          - "Config for HTTP/2 support."
+          - "Keys and values are the same as in L(node_exporter docs,https://github.com/prometheus/node_exporter/blob/master/https/README.md#sample-config)."
+        type: "dict"
+        elements: "str"
+      node_exporter_basic_auth_users:
+        description: "Dictionary of users and password for basic authentication. Passwords are automatically hashed with bcrypt."
+        type: "dict"
+        elements: "str"

--- a/roles/prometheus/meta/argument_specs.yml
+++ b/roles/prometheus/meta/argument_specs.yml
@@ -1,0 +1,145 @@
+---
+argument_specs:
+  main:
+    short_description: "Installs and configures prometheus"
+    description:
+      - "Prometheus monitoring system configuration and management"
+    author:
+      - "Prometheus Community"
+    options:
+      prometheus_version:
+        description:
+          - "Prometheus package version. Also accepts C(latest) as parameter."
+          - "Only prometheus 2.x is supported"
+        default: "2.27.0"
+      prometheus_skip_install:
+        description: "Prometheus installation tasks gets skipped when set to true."
+        type: bool
+        default: false
+      prometheus_binary_local_dir:
+        description:
+          - "Allows to use local packages instead of ones distributed on github."
+          - "As parameter it takes a directory where I(prometheus) AND I(promtool) binaries are stored on host on which ansible is ran."
+          - "This overrides I(prometheus_version) parameter"
+      prometheus_config_dir:
+        description: "Path to directory with prometheus configuration"
+        default: "/etc/prometheus"
+      prometheus_db_dir:
+        description: "Path to directory with prometheus database"
+        default: "/var/lib/prometheus"
+      prometheus_read_only_dirs:
+        description: "Additional paths that Prometheus is allowed to read (useful for SSL certs outside of the config directory)"
+        type: "list"
+        elements: "str"
+      prometheus_web_listen_address:
+        description: "Address on which prometheus will be listening"
+        default: "0.0.0.0:9090"
+      prometheus_web_config:
+        description: "A Prometheus L(web config yaml,https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md)
+                      for configuring TLS and auth."
+        type: "dict"
+        elements: "dict"
+      prometheus_web_external_url:
+        description: "External address on which prometheus is available. Useful when behind reverse proxy. Ex. `http://example.org/prometheus`"
+      prometheus_storage_retention:
+        description: "Data retention period"
+        default: "30d"
+      prometheus_storage_retention_size:
+        description: "Data retention period by size"
+        type: "int"
+        default: 0
+      prometheus_config_flags_extra:
+        description: "Additional configuration flags passed to prometheus binary at startup"
+        type: "dict"
+        elements: "str"
+      prometheus_alertmanager_config:
+        description:
+          - "Configuration responsible for pointing where alertmanagers are. This should be specified as list in yaml format."
+          - "It is compatible with the official
+             L(alertmanager_config,https://prometheus.io/docs/prometheus/latest/configuration/configuration/#alertmanager_config)"
+        type: "list"
+        elements: "str"
+      prometheus_alert_relabel_configs:
+        description:
+          - "Alert relabeling rules. This should be specified as list in yaml format."
+          - "It is compatible with the official
+             L(alert_relabel_configs,https://prometheus.io/docs/prometheus/latest/configuration/configuration/#alert_relabel_configs)"
+        type: "list"
+        elements: "str"
+      prometheus_global:
+        description:
+          - "Prometheus global config. It is compatible with the
+             L(official configuration,https://prometheus.io/docs/prometheus/latest/configuration/configuration/#configuration-file)"
+        type: "dict"
+        elements: "str"
+        default:
+          scrape_interval: "60s"
+          scrape_timeout: "15s"
+          evaluation_interval: "15s"
+      prometheus_remote_write:
+        description:
+          - "Remote write. Compatible with the
+             L(official configuration,https://prometheus.io/docs/prometheus/latest/configuration/configuration/#<remote_write>)"
+        type: "list"
+        elements: "str"
+      prometheus_remote_read:
+        description:
+          - "Remote read. It is compatible with the
+             L(official configuration,https://prometheus.io/docs/prometheus/latest/configuration/configuration/#<remote_read>)"
+        type: "list"
+        elements: "str"
+      prometheus_external_labels:
+        description: "Provide map of additional labels which will be added to any time series or alerts when communicating with external systems"
+        type: "dict"
+        elements: "str"
+        default:
+          environment: "{{ ansible_fqdn | default(ansible_host) | default(inventory_hostname) }}"
+      prometheus_targets:
+        description:
+          - "Targets which will be scraped. Better example is provided in our
+             L(demo site,https://github.com/cloudalchemy/demo-site/blob/2a8a56fc10ce613d8b08dc8623230dace6704f9a/group_vars/all/vars#L8)"
+        type: "dict"
+        elements: "str"
+      prometheus_scrape_configs:
+        description:
+          - "Prometheus scrape jobs provided in same format as in the
+             L(official docs,https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config)"
+        type: "list"
+        elements: "dict"
+        default:
+          - job_name: "prometheus"
+            metrics_path: "{{ prometheus_metrics_path }}"
+            static_configs:
+              - targets:
+                  - "{{ ansible_fqdn | default(ansible_host) | default('localhost') }}:9090"
+          - job_name: "node"
+            file_sd_configs:
+              - files:
+                  - "{{ prometheus_config_dir }}/file_sd/node.yml"
+      prometheus_config_file:
+        description: "Variable used to provide custom prometheus configuration file in form of ansible template"
+        default: "prometheus.yml.j2"
+      prometheus_alert_rules:
+        description:
+          - "Full list of alerting rules which will be copied to C({{ prometheus_config_dir }}/rules/ansible_managed.rules)."
+          - "Alerting rules can be also provided by other files located in C({{ prometheus_config_dir }}/rules/) which have C(*.rules) extension"
+          - "Please see default values in role defaults/main.yml"
+        type: "list"
+        elements: "dict"
+      prometheus_alert_rules_files:
+        description:
+          - "List of folders where ansible will look for files containing alerting rules which will be copied to C({{ prometheus_config_dir }}/rules/)."
+          - "Files must have C(*.rules) extension"
+        type: "list"
+        elements: "str"
+        default:
+          - "prometheus/rules/*.rules"
+      prometheus_static_targets_files:
+        description:
+          - "List of folders where ansible will look for files containing custom static target configuration files
+             which will be copied to C({{ prometheus_config_dir }}/file_sd/)."
+        type: "list"
+        elements: "str"
+        default:
+          - "prometheus/targets/*.yml"
+          - "prometheus/targets/*.json"

--- a/roles/snmp_exporter/meta/argument_specs.yml
+++ b/roles/snmp_exporter/meta/argument_specs.yml
@@ -1,0 +1,19 @@
+---
+argument_specs:
+  main:
+    short_description: "Prometheus SNMP exporter"
+    description:
+      - "Deploy and manage prometheus L(SNMP exporter,https://github.com/prometheus/snmp_exporter) using ansible."
+    author:
+      - "Prometheus Community"
+    options:
+      snmp_exporter_version:
+        description: "SNMP exporter package version"
+        default: "0.19.0"
+      snmp_exporter_web_listen_address:
+        description: "Address on which SNMP exporter will be listening"
+        default: "0.0.0.0:9116"
+      snmp_exporter_config_file:
+        description:
+          - "If this is empty, role will download snmp.yml file from U(https://github.com/prometheus/snmp_exporter)."
+          - "Otherwise this should contain path to file with custom snmp exporter configuration"


### PR DESCRIPTION
Enables parameter validation in roles and opens up the possibility to auto generate docs with [antsibull-docs](https://github.com/ansible-community/antsibull-docs/)