### PR TITLE
feat: Allow grabbing binaries and checksums from a custom url/mirror

### DIFF
--- a/roles/alertmanager/README.md
+++ b/roles/alertmanager/README.md
@@ -20,6 +20,8 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | -------------- | ------------- | -----------------------------------|
 | `alertmanager_version` | 0.21.0 | Alertmanager package version. Also accepts `latest` as parameter. |
 | `alertmanager_binary_local_dir` | "" | Allows to use local packages instead of ones distributed on github. As parameter it takes a directory where `alertmanager` AND `amtool` binaries are stored on host on which ansible is ran. This overrides `alertmanager_version` parameter |
+| `alertmanager_binary_url` | `https://github.com/prometheus/alertmanager/releases/download/v{{ alertmanager_version }}/alertmanager-{{ alertmanager_version }}.linux-{{ go_arch }}.tar.gz` | URL of the alertmanager binaries .tar.gz file |
+| `alertmanager_checksums_url` | `https://github.com/prometheus/alertmanager/releases/download/v{{ alertmanager_version }}/sha256sums.txt` | URL of the alertmanager checksums file |
 | `alertmanager_web_listen_address` | 0.0.0.0:9093 | Address on which alertmanager will be listening |
 | `alertmanager_web_external_url` | http://localhost:9093/ | External address on which alertmanager is available. Useful when behind reverse proxy. Ex. example.org/alertmanager |
 | `alertmanager_config_dir` | /etc/alertmanager | Path to directory with alertmanager configuration |

--- a/roles/alertmanager/defaults/main.yml
+++ b/roles/alertmanager/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 alertmanager_version: 0.21.0
 alertmanager_binary_local_dir: ''
+alertmanager_binary_url: "https://github.com/prometheus/alertmanager/releases/download/v{{ alertmanager_version }}/\
+                          alertmanager-{{ alertmanager_version }}.linux-{{ go_arch }}.tar.gz"
+alertmanager_checksums_url: "https://github.com/prometheus/alertmanager/releases/download/v{{ alertmanager_version }}/sha256sums.txt"
 
 alertmanager_config_dir: /etc/alertmanager
 alertmanager_db_dir: /var/lib/alertmanager

--- a/roles/alertmanager/tasks/install.yml
+++ b/roles/alertmanager/tasks/install.yml
@@ -33,8 +33,7 @@
     - name: Download alertmanager binary to local folder
       become: false
       ansible.builtin.get_url:
-        url: "https://github.com/prometheus/alertmanager/releases/download/v{{ alertmanager_version }}/\
-              alertmanager-{{ alertmanager_version }}.linux-{{ go_arch }}.tar.gz"
+        url: "{{ alertmanager_binary_url }}"
         dest: "/tmp/alertmanager-{{ alertmanager_version }}.linux-{{ go_arch }}.tar.gz"
         checksum: "sha256:{{ __alertmanager_checksum }}"
         mode: 0644

--- a/roles/alertmanager/tasks/preflight.yml
+++ b/roles/alertmanager/tasks/preflight.yml
@@ -33,8 +33,7 @@
   block:
     - name: "Get checksum list"
       ansible.builtin.set_fact:
-        __alertmanager_checksums: "{{ lookup('url', 'https://github.com/prometheus/alertmanager/releases/download/v' + alertmanager_version +
-                                   '/sha256sums.txt', wantlist=True) | list }}"
+        __alertmanager_checksums: "{{ lookup('url', alertmanager_checksums_url, wantlist=True) | list }}"
       run_once: true
       until: __alertmanager_checksums is search('linux-' + go_arch + '.tar.gz')
       retries: 10

--- a/roles/blackbox_exporter/README.md
+++ b/roles/blackbox_exporter/README.md
@@ -18,6 +18,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
 | `blackbox_exporter_version` | 0.18.0 | Blackbox exporter package version |
+| `blackbox_exporter_binary_url` | `"https://github.com/prometheus/blackbox_exporter/releases/download/v{{ blackbox_exporter_version }}/blackbox_exporter-{{ blackbox_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"` | URL of the blackbox exporter binaries .tar.gz file |
 | `blackbox_exporter_web_listen_address` | 0.0.0.0:9115 | Address on which blackbox exporter will be listening |
 | `blackbox_exporter_cli_flags` | {} | Additional configuration flags passed to blackbox exporter binary at startup |
 | `blackbox_exporter_configuration_modules` | http_2xx: { prober: http, timeout: 5s, http: '' } | |

--- a/roles/blackbox_exporter/defaults/main.yml
+++ b/roles/blackbox_exporter/defaults/main.yml
@@ -1,5 +1,8 @@
 ---
 blackbox_exporter_version: 0.18.0
+blackbox_exporter_binary_url: "https://github.com/prometheus/blackbox_exporter/releases/download/v{{ blackbox_exporter_version }}/\
+                               blackbox_exporter-{{ blackbox_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] |
+                               default(ansible_architecture) }}.tar.gz"
 
 blackbox_exporter_web_listen_address: "0.0.0.0:9115"
 

--- a/roles/blackbox_exporter/tasks/install.yml
+++ b/roles/blackbox_exporter/tasks/install.yml
@@ -16,8 +16,7 @@
 - name: Download blackbox exporter binary to local folder
   become: false
   ansible.builtin.unarchive:
-    src: "https://github.com/prometheus/blackbox_exporter/releases/download/v{{ blackbox_exporter_version }}/\
-          blackbox_exporter-{{ blackbox_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
+    src: "{{ blackbox_exporter_binary_url }}"
     dest: "/tmp"
     remote_src: true
     creates: "/tmp/blackbox_exporter-{{ blackbox_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/\

--- a/roles/node_exporter/README.md
+++ b/roles/node_exporter/README.md
@@ -24,6 +24,8 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | -------------- | ------------- | -----------------------------------|
 | `node_exporter_version` | 1.1.2 | Node exporter package version. Also accepts latest as parameter. |
 | `node_exporter_binary_local_dir` | "" | Enables the use of local packages instead of those distributed on github. The parameter may be set to a directory where the `node_exporter` binary is stored on the host where ansible is run. This overrides the `node_exporter_version` parameter |
+| `node_exporter_binary_url` | `https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz` | URL of the node exporter binaries .tar.gz file |
+| `node_exporter_checksums_url` | `https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/sha256sums.txt` | URL of the node exporter checksums file |
 | `node_exporter_web_listen_address` | "0.0.0.0:9100" | Address on which node exporter will listen |
 | `node_exporter_web_telemetry_path` | "/metrics" | Path under which to expose metrics |
 | `node_exporter_enabled_collectors` | ```["systemd",{textfile: {directory: "{{node_exporter_textfile_dir}}"}}]``` | List of dicts defining additionally enabled collectors and their configuration. It adds collectors to [those enabled by default](https://github.com/prometheus/node_exporter#enabled-by-default). |

--- a/roles/node_exporter/defaults/main.yml
+++ b/roles/node_exporter/defaults/main.yml
@@ -1,6 +1,10 @@
 ---
 node_exporter_version: 1.1.2
 node_exporter_binary_local_dir: ""
+node_exporter_binary_url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/\
+                           node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
+node_exporter_checksums_url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/sha256sums.txt"
+
 node_exporter_web_listen_address: "0.0.0.0:9100"
 node_exporter_web_telemetry_path: "/metrics"
 

--- a/roles/node_exporter/tasks/install.yml
+++ b/roles/node_exporter/tasks/install.yml
@@ -24,8 +24,7 @@
     - name: Download node_exporter binary to local folder
       become: false
       ansible.builtin.get_url:
-        url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/\
-              node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
+        url: "{{ node_exporter_binary_url }}"
         dest: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
         checksum: "sha256:{{ __node_exporter_checksum }}"
         mode: '0644'

--- a/roles/node_exporter/tasks/preflight.yml
+++ b/roles/node_exporter/tasks/preflight.yml
@@ -86,8 +86,7 @@
   block:
     - name: Get checksum list from github
       ansible.builtin.set_fact:
-        __node_exporter_checksums: "{{ lookup('url', 'https://github.com/prometheus/node_exporter/releases/download/v' + node_exporter_version +
-                                    '/sha256sums.txt', wantlist=True) | list }}"
+        __node_exporter_checksums: "{{ lookup('url', node_exporter_checksums_url, wantlist=True) | list }}"
       run_once: true
       until: __node_exporter_checksums is search('linux-' + go_arch + '.tar.gz')
       retries: 10

--- a/roles/prometheus/README.md
+++ b/roles/prometheus/README.md
@@ -26,6 +26,8 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `prometheus_skip_install` | false | Prometheus installation tasks gets skipped when set to true. |
 | `prometheus_binary_local_dir` | "" | Allows to use local packages instead of ones distributed on github. As parameter it takes a directory where `prometheus` AND `promtool` binaries are stored on host on which ansible is ran. This overrides `prometheus_version` parameter |
 | `prometheus_config_dir` | /etc/prometheus | Path to directory with prometheus configuration |
+| `prometheus_binary_url` | `https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz` | URL of the prometheus binaries .tar.gz file |
+| `prometheus_checksums_url` | `https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/sha256sums.txt` | URL of the prometheus checksums file |
 | `prometheus_db_dir` | /var/lib/prometheus | Path to directory with prometheus database |
 | `prometheus_read_only_dirs`| [] | Additional paths that Prometheus is allowed to read (useful for SSL certs outside of the config directory) |
 | `prometheus_web_listen_address` | "0.0.0.0:9090" | Address on which prometheus will be listening |

--- a/roles/prometheus/defaults/main.yml
+++ b/roles/prometheus/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 prometheus_version: 2.27.0
 prometheus_binary_local_dir: ''
+prometheus_binary_url: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/\
+                        prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
+prometheus_checksums_url: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/sha256sums.txt"
 prometheus_skip_install: false
 
 prometheus_config_dir: /etc/prometheus

--- a/roles/prometheus/tasks/install.yml
+++ b/roles/prometheus/tasks/install.yml
@@ -43,8 +43,7 @@
     - name: Download prometheus binary to local folder
       become: false
       ansible.builtin.get_url:
-        url: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/\
-              prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
+        url: "{{ prometheus_binary_url }}"
         dest: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
         checksum: "sha256:{{ __prometheus_checksum }}"
         mode: 0644

--- a/roles/prometheus/tasks/preflight.yml
+++ b/roles/prometheus/tasks/preflight.yml
@@ -91,8 +91,7 @@
   block:
     - name: "Get checksum list"
       ansible.builtin.set_fact:
-        __prometheus_checksums: "{{ lookup('url', 'https://github.com/prometheus/prometheus/releases/download/v' + prometheus_version + '/sha256sums.txt',
-                                 wantlist=True) | list }}"
+        __prometheus_checksums: "{{ lookup('url', prometheus_checksums_url, wantlist=True) | list }}"
       run_once: true
       until: __prometheus_checksums is search('linux-' + go_arch + '.tar.gz')
       retries: 10

--- a/roles/snmp_exporter/README.md
+++ b/roles/snmp_exporter/README.md
@@ -17,6 +17,8 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
 | `snmp_exporter_version` | 0.19.0 | SNMP exporter package version |
+| `snmp_exporter_binary_url` | `https://github.com/prometheus/snmp_exporter/releases/download/v{{ snmp_exporter_version }}/snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz` | URL of the snmp exporter binaries .tar.gz file |
+| `snmp_exporter_checksums_url` | `https://github.com/prometheus/snmp_exporter/releases/download/v{{ snmp_exporter_version }}/sha256sums.txt` | URL of the snmp exporter checksums file |
 | `snmp_exporter_web_listen_address` | "0.0.0.0:9116" | Address on which SNMP exporter will be listening |
 | `snmp_exporter_config_file` | "" | If this is empty, role will download snmp.yml file from https://github.com/prometheus/snmp_exporter. Otherwise this should contain path to file with custom snmp exporter configuration |
 

--- a/roles/snmp_exporter/defaults/main.yml
+++ b/roles/snmp_exporter/defaults/main.yml
@@ -1,5 +1,8 @@
 ---
 snmp_exporter_version: 0.19.0
+snmp_exporter_binary_url: "https://github.com/prometheus/snmp_exporter/releases/download/v{{ snmp_exporter_version }}/\
+                           snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
+snmp_exporter_checksums_url: "https://github.com/prometheus/snmp_exporter/releases/download/v{{ snmp_exporter_version }}/sha256sums.txt"
 snmp_exporter_web_listen_address: "0.0.0.0:9116"
 snmp_exporter_log_level: info
 

--- a/roles/snmp_exporter/tasks/install.yml
+++ b/roles/snmp_exporter/tasks/install.yml
@@ -2,8 +2,7 @@
 - name: Download snmp_exporter binary to local folder
   become: false
   ansible.builtin.get_url:
-    url: "https://github.com/prometheus/snmp_exporter/releases/download/v{{ snmp_exporter_version }}/\
-          snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
+    url: "{{ snmp_exporter_binary_url }}"
     dest: "/tmp"
     checksum: "sha256:{{ snmp_exporter_checksum }}"
     mode: 0644

--- a/roles/snmp_exporter/tasks/preflight.yml
+++ b/roles/snmp_exporter/tasks/preflight.yml
@@ -3,5 +3,5 @@
   ansible.builtin.set_fact:
     snmp_exporter_checksum: "{{ item.split(' ')[0] }}"
   with_items:
-    - "{{ lookup('url', 'https://github.com/prometheus/snmp_exporter/releases/download/v' + snmp_exporter_version + '/sha256sums.txt', wantlist=True) | list }}"
+    - "{{ lookup('url', snmp_exporter_checksums_url, wantlist=True) | list }}"
   when: "('linux-' + (go_arch_map[ansible_architecture] | default(ansible_architecture)) + '.tar.gz') in item"


### PR DESCRIPTION
Allows grabbing binaries and checksums from a custom url/mirror, useful in closed environments where it's not possible to reach github.