### PR TITLE
fix: use workflow trigger that gives writable token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 ---
 name: Ansible collection release
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
 


### PR DESCRIPTION
Apparently when the `pull_request` trigger is used the workflow gets a read only github token, switching to `pull_request_target` should give writable token.