### PR TITLE
fix: correct workflow triggers and writable permissions

### DIFF
--- a/.github/workflows/ansible-ci.yml
+++ b/.github/workflows/ansible-ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches-ignore:
       - main
-  pull_request_target:
+  pull_request:
     types:
-      - '!closed'
+      - opened
+      - edited
+      - reopened
   workflow_dispatch:
 
 env:

--- a/.github/workflows/conventional-label.yml
+++ b/.github/workflows/conventional-label.yml
@@ -2,13 +2,15 @@
 on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
+permissions:
+  pull-requests: write
 name: Auto label pull request
 jobs:
   label:
     runs-on: ubuntu-latest
     steps:
       - name: "Confirm correct pull request title"
-        uses: deepakputhraya/action-pr-title@master
+        uses: mmubeen/action-pr-title@master # until PR gets merged https://github.com/deepakputhraya/action-pr-title/pull/29
         with:
           allowed_prefixes: 'feat,feature,fix,major,breaking,minor,enhancement,deprecated,removed,security,bug,bugfix,docs,packaging,test,refactor,refactoring,skip-release,skip_changelog'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,10 @@ jobs:
   release:
     if: |
       github.event.pull_request.merged &&
-      github.ref == github.event.repository.default_branch &&
       !contains(github.event.pull_request.labels.*.name, 'skip_changelog')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
         with:
@@ -30,7 +31,7 @@ jobs:
         run: antsibull-changelog release -v --version "${{ steps.version.outputs.next-version }}"
 
       - name: "Run antsichaut"
-        uses: rndmh3ro/antsichaut-action@main
+        uses: gardar/antsichaut-action@latest  # Until new pip release gets published:  https://github.com/rndmh3ro/antsichaut/issues/7
         with:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           since_version: "${{ steps.version.outputs.current-version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         run: antsibull-changelog release -v --version "${{ steps.version.outputs.next-version }}"
 
       - name: "Run antsichaut"
-        uses: gardar/antsichaut-action@latest  # Until new pip release gets published:  https://github.com/rndmh3ro/antsichaut/issues/7
+        uses: rndmh3ro/antsichaut-action@main
         with:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           since_version: "${{ steps.version.outputs.current-version }}"


### PR DESCRIPTION
#29 and #30 didn't quite do the trick, this adds the required writable permissions to `pull_request_target` and also fixes triggers for workflows that got skipped after moving from `pull_request` to `pull_request_target`

Didn't catch these permission errors before since they were tested in my fork where I have write permissions, but now it's been tested in a separate fork where I gave myself restricted permissions.