### PR TITLE
fix: grab dependencies from github to avoid galaxy timeouts

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,6 @@
 ---
 collections:
-  - community.general
-  - community.crypto
+  - name: https://github.com/ansible-collections/community.general.git
+    type: git
+  - name: https://github.com/ansible-collections/community.crypto.git
+    type: git

--- a/tests/integration/molecule.sh
+++ b/tests/integration/molecule.sh
@@ -25,7 +25,7 @@ if [ "$(printf '%s\n' "2.12" "$ansible_version" | sort -V | head -n1)" = "2.12" 
        python -m pip install molecule molecule-plugins[docker]
 else
        python -m pip install molecule molecule-docker
-       ansible-galaxy collection install community.docker
+       ansible-galaxy collection install git+https://github.com/ansible-collections/community.docker.git
        ansible-galaxy collection install -r "$collection_root/requirements.yml"
 fi
 


### PR DESCRIPTION
Ansible galaxy frequently has timeout issues which makes the testing fail, we can limit the calls to galaxy by grabbing the collection dependencies directly from their git repos.