### PR TITLE
fix: avoid installing changelog tools when testing

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,3 @@
-antsibull-changelog
-antsichaut
 molecule
 docker
 ansible-lint


### PR DESCRIPTION
- Fixes regression introduced in #26 where ansible 2.9, 2.10, 2.11 tests are failing due to `antsichaut` not being compatible with those python versions. (see: https://github.com/prometheus-community/ansible/actions/runs/4308763450)
- There is no need to install changelog tools when running collection tests, and removing them cuts down the time it takes to run the tests.