### PR TITLE
removed: remove lint from molecule to avoid repetition

### DIFF
--- a/.config/molecule/config.yml
+++ b/.config/molecule/config.yml
@@ -3,10 +3,6 @@ dependency:
   name: galaxy
 driver:
   name: docker
-lint: |
-  set -e
-  yamllint -c ${YAMLLINT_CONFIG_FILE} .
-  ansible-lint
 platforms:
   - name: almalinux-8
     image: dokken/almalinux-8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,8 +1,6 @@
 molecule
 docker
-ansible-lint
 pytest-testinfra
 jmespath
 selinux
 passlib
-yamllint


### PR DESCRIPTION
The linting is done as a separate CI job, so there is no need to spend time running ansible-lint each time molecule tests run.
And lint has been removed from molecule v5: https://github.com/ansible-community/molecule/pull/3802