### PR TITLE
fix: Force push git changelogs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           branch: ${{ github.event.pull_request.base.ref }}
           commit_message: "chore: update version"
+          push_options: --force
 
       - name: "Checkout updated branch"
         uses: actions/checkout@v3


### PR DESCRIPTION
We need to use force push to update skipping the default branch protection rules.