### PR TITLE
refactor: move yamllint cfg to standard path

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -21,3 +21,6 @@ rules:
     level: error
   line-length:
     max: 160
+
+ignore: |
+  changelogs/.plugin-cache.yaml

--- a/tests/integration/molecule.sh
+++ b/tests/integration/molecule.sh
@@ -42,7 +42,7 @@ fi
 
 # Define config locations within collection
 export MOLECULE_FILE=$collection_root/.config/molecule/config.yml
-export YAMLLINT_CONFIG_FILE=$collection_root/.config/yamllint/config.yml
+export YAMLLINT_CONFIG_FILE=$collection_root/.yamllint.yml
 
 # Unset ansible-test variables that break molecule
 unset _ANSIBLE_COVERAGE_CONFIG


### PR DESCRIPTION
Moved to standard path according to the [docs](https://yamllint.readthedocs.io/en/stable/configuration.html#default-configuration)
The [ansible/ansible-lint-action](https://github.com/ansible/ansible-lint-action) didn't pick up the yamllint cfg at the other path.