### PR TITLE
New prometheus/node_exporter upstream release!

### DIFF
--- a/roles/node_exporter/README.md
+++ b/roles/node_exporter/README.md
@@ -18,7 +18,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
-| `node_exporter_version` | 1.1.2 | Node exporter package version. Also accepts latest as parameter. |
+| `node_exporter_version` | 1.5.0 | Node exporter package version. Also accepts latest as parameter. |
 | `node_exporter_binary_local_dir` | "" | Enables the use of local packages instead of those distributed on github. The parameter may be set to a directory where the `node_exporter` binary is stored on the host where ansible is run. This overrides the `node_exporter_version` parameter |
 | `node_exporter_binary_url` | `https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz` | URL of the node exporter binaries .tar.gz file |
 | `node_exporter_checksums_url` | `https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/sha256sums.txt` | URL of the node exporter checksums file |

--- a/roles/node_exporter/defaults/main.yml
+++ b/roles/node_exporter/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-node_exporter_version: 1.1.2
+node_exporter_version: 1.5.0
 node_exporter_binary_local_dir: ""
 node_exporter_binary_url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/\
                            node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"


### PR DESCRIPTION
The upstream [prometheus/node_exporter](https://github.com/prometheus/node_exporter) released new software version - **1.5.0**! This automated PR updates code to bring new version into repository.

## Commit Message
create [patch] release