### PR TITLE
fix: various role argument specs

### DIFF
--- a/roles/alertmanager/meta/argument_specs.yml
+++ b/roles/alertmanager/meta/argument_specs.yml
@@ -15,6 +15,13 @@ argument_specs:
           - "Allows to use local packages instead of ones distributed on github."
           - "As parameter it takes a directory where C(alertmanager) AND C(amtool) binaries are stored on host on which ansible is ran."
           - "This overrides I(alertmanager_version) parameter"
+      alertmanager_binary_url:
+        description: "URL of the alertmanager binaries .tar.gz file"
+        default: "https://github.com/prometheus/alertmanager/releases/download/v{{ alertmanager_version }}/\
+                  alertmanager-{{ alertmanager_version }}.linux-{{ go_arch }}.tar.gz"
+      alertmanager_checksums_url:
+        description: "URL of the alertmanager checksums file"
+        default: "https://github.com/prometheus/alertmanager/releases/download/v{{ alertmanager_version }}/sha256sums.txt"
       alertmanager_web_listen_address:
         description: "Address on which alertmanager will be listening"
         default: "0.0.0.0:9093"

--- a/roles/blackbox_exporter/meta/argument_specs.yml
+++ b/roles/blackbox_exporter/meta/argument_specs.yml
@@ -16,11 +16,9 @@ argument_specs:
       blackbox_exporter_cli_flags:
         description: "Additional configuration flags passed to blackbox exporter binary at startup"
         type: "dict"
-        elements: "str"
       blackbox_exporter_configuration_modules:
         description: "Endpoints configuration"
         type: "dict"
-        elements: "dict"
         default:
           http_2xx:
             prober: http

--- a/roles/node_exporter/meta/argument_specs.yml
+++ b/roles/node_exporter/meta/argument_specs.yml
@@ -15,6 +15,13 @@ argument_specs:
           - "Enables the use of local packages instead of those distributed on github."
           - "The parameter may be set to a directory where the C(node_exporter) binary is stored on the host where ansible is run."
           - "This overrides the I(node_exporter_version) parameter"
+      node_exporter_binary_url:
+        description: "URL of the node exporter binaries .tar.gz file"
+        default: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/\
+                  node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
+      node_exporter_checksums_url:
+        description: "URL of the node exporter checksums file"
+        default: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/sha256sums.txt"
       node_exporter_web_listen_address:
         description: "Address on which node exporter will listen"
         default: "0.0.0.0:9100"
@@ -47,14 +54,11 @@ argument_specs:
           - "Configuration for TLS authentication."
           - "Keys and values are the same as in L(node_exporter docs,https://github.com/prometheus/node_exporter/blob/master/https/README.md#sample-config)."
         type: "dict"
-        elements: "str"
       node_exporter_http_server_config:
         description:
           - "Config for HTTP/2 support."
           - "Keys and values are the same as in L(node_exporter docs,https://github.com/prometheus/node_exporter/blob/master/https/README.md#sample-config)."
         type: "dict"
-        elements: "str"
       node_exporter_basic_auth_users:
         description: "Dictionary of users and password for basic authentication. Passwords are automatically hashed with bcrypt."
         type: "dict"
-        elements: "str"

--- a/roles/prometheus/defaults/main.yml
+++ b/roles/prometheus/defaults/main.yml
@@ -12,6 +12,7 @@ prometheus_read_only_dirs: []
 
 prometheus_web_listen_address: "0.0.0.0:9090"
 prometheus_web_external_url: ''
+prometheus_metrics_path: "/{{ (prometheus_web_external_url + '/metrics') | regex_replace('^(.*://)?(.*?)/') }}"
 # See https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md
 prometheus_web_config:
   tls_server_config: {}

--- a/roles/prometheus/meta/argument_specs.yml
+++ b/roles/prometheus/meta/argument_specs.yml
@@ -38,7 +38,6 @@ argument_specs:
         description: "A Prometheus L(web config yaml,https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md)
                       for configuring TLS and auth."
         type: "dict"
-        elements: "dict"
       prometheus_web_external_url:
         description: "External address on which prometheus is available. Useful when behind reverse proxy. Ex. `http://example.org/prometheus`"
       prometheus_metrics_path:
@@ -54,7 +53,6 @@ argument_specs:
       prometheus_config_flags_extra:
         description: "Additional configuration flags passed to prometheus binary at startup"
         type: "dict"
-        elements: "str"
       prometheus_alertmanager_config:
         description:
           - "Configuration responsible for pointing where alertmanagers are. This should be specified as list in yaml format."
@@ -74,7 +72,6 @@ argument_specs:
           - "Prometheus global config. It is compatible with the
              L(official configuration,https://prometheus.io/docs/prometheus/latest/configuration/configuration/#configuration-file)"
         type: "dict"
-        elements: "str"
         default:
           scrape_interval: "60s"
           scrape_timeout: "15s"
@@ -94,14 +91,12 @@ argument_specs:
       prometheus_external_labels:
         description: "Provide map of additional labels which will be added to any time series or alerts when communicating with external systems"
         type: "dict"
-        elements: "str"
         default:
           environment: "{{ ansible_fqdn | default(ansible_host) | default(inventory_hostname) }}"
       prometheus_targets:
         description:
           - "Targets which will be scraped."
         type: "dict"
-        elements: "str"
       prometheus_scrape_configs:
         description:
           - "Prometheus scrape jobs provided in same format as in the

--- a/roles/prometheus/meta/argument_specs.yml
+++ b/roles/prometheus/meta/argument_specs.yml
@@ -47,9 +47,11 @@ argument_specs:
         description: "Data retention period"
         default: "30d"
       prometheus_storage_retention_size:
-        description: "Data retention period by size"
-        type: "int"
-        default: 0
+        description:
+          - "Data retention period by size"
+          - "Maximum number of bytes that can be stored for blocks."
+          - "Units supported: KB, MB, GB, TB, PB."
+        default: "0"
       prometheus_config_flags_extra:
         description: "Additional configuration flags passed to prometheus binary at startup"
         type: "dict"

--- a/roles/prometheus/meta/argument_specs.yml
+++ b/roles/prometheus/meta/argument_specs.yml
@@ -41,6 +41,9 @@ argument_specs:
         elements: "dict"
       prometheus_web_external_url:
         description: "External address on which prometheus is available. Useful when behind reverse proxy. Ex. `http://example.org/prometheus`"
+      prometheus_metrics_path:
+        description: "Prometheus external metrics path"
+        default: "/metrics"
       prometheus_storage_retention:
         description: "Data retention period"
         default: "30d"

--- a/roles/prometheus/meta/argument_specs.yml
+++ b/roles/prometheus/meta/argument_specs.yml
@@ -21,6 +21,13 @@ argument_specs:
           - "Allows to use local packages instead of ones distributed on github."
           - "As parameter it takes a directory where I(prometheus) AND I(promtool) binaries are stored on host on which ansible is ran."
           - "This overrides I(prometheus_version) parameter"
+      prometheus_binary_url:
+        description: "URL of the prometheus binaries .tar.gz file"
+        default: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/\
+                  prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
+      prometheus_checksums_url:
+        description: URL of the prometheus checksums file
+        default: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/sha256sums.txt"
       prometheus_config_dir:
         description: "Path to directory with prometheus configuration"
         default: "/etc/prometheus"
@@ -42,9 +49,10 @@ argument_specs:
         description: "External address on which prometheus is available. Useful when behind reverse proxy. Ex. `http://example.org/prometheus`"
       prometheus_metrics_path:
         description: "Prometheus external metrics path"
-        default: "/metrics"
+        default: "/{{ (prometheus_web_external_url + '/metrics') | regex_replace('^(.*://)?(.*?)/') }}"
       prometheus_storage_retention:
-        description: "Data retention period"
+        description:
+          - "Data retention period"
         default: "30d"
       prometheus_storage_retention_size:
         description:
@@ -53,7 +61,9 @@ argument_specs:
           - "Units supported: KB, MB, GB, TB, PB."
         default: "0"
       prometheus_config_flags_extra:
-        description: "Additional configuration flags passed to prometheus binary at startup"
+        description:
+          - "Additional configuration flags passed to prometheus binary at startup"
+          - "Example: prometheus_config_flags_extra: { storage.tsdb.retention: 15d, alertmanager.timeout: 10s }"
         type: "dict"
       prometheus_alertmanager_config:
         description:

--- a/roles/prometheus/tasks/preflight.yml
+++ b/roles/prometheus/tasks/preflight.yml
@@ -31,10 +31,6 @@
     that: prometheus_global.external_labels is not defined
     msg: "Use prometheus_external_labels to define external labels"
 
-- name: Set prometheus external metrics path
-  ansible.builtin.set_fact:
-    prometheus_metrics_path: "/{{ (prometheus_web_external_url + '/metrics') | regex_replace('^(.*://)?(.*?)/') }}"
-
 - name: Fail when prometheus_config_flags_extra duplicates parameters set by other variables
   ansible.builtin.fail:
     msg: >

--- a/roles/snmp_exporter/meta/argument_specs.yml
+++ b/roles/snmp_exporter/meta/argument_specs.yml
@@ -10,9 +10,19 @@ argument_specs:
       snmp_exporter_version:
         description: "SNMP exporter package version"
         default: "0.19.0"
+      snmp_exporter_binary_url:
+        description: "URL of the snmp exporter binaries .tar.gz file"
+        default: "https://github.com/prometheus/snmp_exporter/releases/download/v{{ snmp_exporter_version }}/\
+                  snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
+      snmp_exporter_checksums_url:
+        description: "URL of the snmp exporter checksums file"
+        default: "https://github.com/prometheus/snmp_exporter/releases/download/v{{ snmp_exporter_version }}/sha256sums.txt"
       snmp_exporter_web_listen_address:
         description: "Address on which SNMP exporter will be listening"
         default: "0.0.0.0:9116"
+      snmp_exporter_log_level:
+        description: "SNMP exporter service log level"
+        default: info
       snmp_exporter_config_file:
         description:
           - "If this is empty, role will download snmp.yml file from U(https://github.com/prometheus/snmp_exporter)."


### PR DESCRIPTION
- Moves variables referenced from other variables out of tasks and into defaults.
- Adds missing argument specs for binary/checksum urls #28 
- Removes element validation from dict since it's only available on lists.