### PR TITLE
skip_changelog: Trigger test CI workflow on PR commits

### DIFF
--- a/.github/workflows/ansible-ci.yml
+++ b/.github/workflows/ansible-ci.yml
@@ -9,6 +9,7 @@ on:
       - opened
       - edited
       - reopened
+      - synchronize
   workflow_dispatch:
 
 env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.tar.gz
+__pycache__/


### PR DESCRIPTION
Fixes the issue where the ansible ci workflow didn't run on new commits / rebase in already open PR's, so problematic code can go undetected when added to already open PR's.

Also added pycache dirs to gitignore, these cache dirs get left behind when running molecule locally.