### PR TITLE
refactor: avoid using command module for systemd version fact

### DIFF
--- a/roles/alertmanager/tasks/preflight.yml
+++ b/roles/alertmanager/tasks/preflight.yml
@@ -4,6 +4,17 @@
     that: ansible_service_mgr == 'systemd'
     msg: "This module only works with systemd"
 
+- name: Install package fact dependencies
+  ansible.builtin.package:
+    name: "{{ _pkg_fact_req }}"
+    state: present
+  when: (_pkg_fact_req)
+  vars:
+    _pkg_fact_req: "{% if (ansible_pkg_mgr == 'apt') %}\
+                    {{ ('python-apt' if ansible_python_version is version('3', '<') else 'python3-apt') }}
+                    {% else %}\
+                    {% endif %}"
+
 - name: Gather package facts
   ansible.builtin.package_facts:
   when: "not 'packages' in ansible_facts"

--- a/roles/alertmanager/tasks/preflight.yml
+++ b/roles/alertmanager/tasks/preflight.yml
@@ -4,17 +4,9 @@
     that: ansible_service_mgr == 'systemd'
     msg: "This module only works with systemd"
 
-- name: Get systemd version
-  ansible.builtin.command: systemctl --version
-  changed_when: false
-  check_mode: false
-  register: __systemd_version
-  tags:
-    - skip_ansible_lint
-
-- name: Set systemd version fact
-  ansible.builtin.set_fact:
-    alertmanager_systemd_version: "{{ __systemd_version.stdout_lines[0].split(' ')[-1] }}"
+- name: Gather package facts
+  ansible.builtin.package_facts:
+  when: "not 'packages' in ansible_facts"
 
 - name: Discover latest version
   ansible.builtin.set_fact:

--- a/roles/alertmanager/templates/alertmanager.service.j2
+++ b/roles/alertmanager/templates/alertmanager.service.j2
@@ -51,7 +51,7 @@ ReadWriteDirectories={{ alertmanager_db_dir }}
 RemoveIPC=true
 RestrictSUIDSGID=true
 
-{% if alertmanager_systemd_version | int >= 232 %}
+{% if (ansible_facts.packages.systemd | first).version is version('232', '>=') %}
 PrivateUsers=true
 ProtectControlGroups=true
 ProtectKernelModules=true

--- a/roles/blackbox_exporter/tasks/preflight.yml
+++ b/roles/blackbox_exporter/tasks/preflight.yml
@@ -4,6 +4,17 @@
     that: ansible_service_mgr == 'systemd'
     msg: "This role only works with systemd"
 
+- name: Install package fact dependencie
+  ansible.builtin.package:
+    name: "{{ _pkg_fact_req }}"
+    state: present
+  when: (_pkg_fact_req)
+  vars:
+    _pkg_fact_req: "{% if (ansible_pkg_mgr == 'apt') %}\
+                    {{ ('python-apt' if ansible_python_version is version('3', '<') else 'python3-apt') }}
+                    {% else %}\
+                    {% endif %}"
+
 - name: Gather package facts
   ansible.builtin.package_facts:
   when: "not 'packages' in ansible_facts"

--- a/roles/blackbox_exporter/tasks/preflight.yml
+++ b/roles/blackbox_exporter/tasks/preflight.yml
@@ -4,17 +4,9 @@
     that: ansible_service_mgr == 'systemd'
     msg: "This role only works with systemd"
 
-- name: Get systemd version
-  ansible.builtin.command: systemctl --version
-  changed_when: false
-  check_mode: false
-  register: __systemd_version
-  tags:
-    - skip_ansible_lint
-
-- name: Set systemd version fact
-  ansible.builtin.set_fact:
-    blackbox_exporter_systemd_version: "{{ __systemd_version.stdout_lines[0] | regex_replace('^systemd\\s(\\d+).*$', '\\1') }}"
+- name: Gather package facts
+  ansible.builtin.package_facts:
+  when: "not 'packages' in ansible_facts"
 
 - name: Naive assertion of proper listen address
   ansible.builtin.assert:

--- a/roles/blackbox_exporter/templates/blackbox_exporter.service.j2
+++ b/roles/blackbox_exporter/templates/blackbox_exporter.service.j2
@@ -32,7 +32,7 @@ RemoveIPC=true
 RestrictSUIDSGID=true
 
 AmbientCapabilities=CAP_NET_RAW
-{% if blackbox_exporter_systemd_version | int >= 232 %}
+{% if (ansible_facts.packages.systemd | first).version is version('232', '>=') %}
 ProtectControlGroups=true
 ProtectKernelModules=true
 ProtectKernelTunables=yes

--- a/roles/node_exporter/tasks/preflight.yml
+++ b/roles/node_exporter/tasks/preflight.yml
@@ -4,6 +4,17 @@
     that: ansible_service_mgr == 'systemd'
     msg: "This role only works with systemd"
 
+- name: Install package fact dependencies
+  ansible.builtin.package:
+    name: "{{ _pkg_fact_req }}"
+    state: present
+  when: (_pkg_fact_req)
+  vars:
+    _pkg_fact_req: "{% if (ansible_pkg_mgr == 'apt') %}\
+                    {{ ('python-apt' if ansible_python_version is version('3', '<') else 'python3-apt') }}
+                    {% else %}\
+                    {% endif %}"
+
 - name: Gather package facts
   ansible.builtin.package_facts:
   when: "not 'packages' in ansible_facts"

--- a/roles/node_exporter/tasks/preflight.yml
+++ b/roles/node_exporter/tasks/preflight.yml
@@ -4,17 +4,9 @@
     that: ansible_service_mgr == 'systemd'
     msg: "This role only works with systemd"
 
-- name: Get systemd version
-  ansible.builtin.command: systemctl --version
-  changed_when: false
-  check_mode: false
-  register: __systemd_version
-  tags:
-    - skip_ansible_lint
-
-- name: Set systemd version fact
-  ansible.builtin.set_fact:
-    node_exporter_systemd_version: "{{ __systemd_version.stdout_lines[0] | regex_replace('^systemd\\s(\\d+).*$', '\\1') }}"
+- name: Gather package facts
+  ansible.builtin.package_facts:
+  when: "not 'packages' in ansible_facts"
 
 - name: Naive assertion of proper listen address
   ansible.builtin.assert:
@@ -68,7 +60,6 @@
   when: __node_exporter_is_installed.stat.exists
   tags:
     - node_exporter_install
-    - skip_ansible_lint
 
 - name: Discover latest version
   ansible.builtin.set_fact:

--- a/roles/node_exporter/templates/node_exporter.service.j2
+++ b/roles/node_exporter/templates/node_exporter.service.j2
@@ -45,7 +45,7 @@ StartLimitInterval=0
 ProtectHome={{ protect_home }}
 NoNewPrivileges=yes
 
-{% if node_exporter_systemd_version | int >= 232 %}
+{% if (ansible_facts.packages.systemd | first).version is version('232', '>=') %}
 ProtectSystem=strict
 ProtectControlGroups=true
 ProtectKernelModules=true

--- a/roles/prometheus/tasks/preflight.yml
+++ b/roles/prometheus/tasks/preflight.yml
@@ -4,6 +4,17 @@
     that: ansible_service_mgr == 'systemd'
     msg: "This module only works with systemd"
 
+- name: Install package fact dependencies
+  ansible.builtin.package:
+    name: "{{ _pkg_fact_req }}"
+    state: present
+  when: (_pkg_fact_req)
+  vars:
+    _pkg_fact_req: "{% if (ansible_pkg_mgr == 'apt') %}\
+                    {{ ('python-apt' if ansible_python_version is version('3', '<') else 'python3-apt') }}
+                    {% else %}\
+                    {% endif %}"
+
 - name: Gather package facts
   ansible.builtin.package_facts:
   when: "not 'packages' in ansible_facts"

--- a/roles/prometheus/tasks/preflight.yml
+++ b/roles/prometheus/tasks/preflight.yml
@@ -4,17 +4,9 @@
     that: ansible_service_mgr == 'systemd'
     msg: "This module only works with systemd"
 
-- name: Get systemd version
-  ansible.builtin.command: systemctl --version
-  changed_when: false
-  check_mode: false
-  register: __systemd_version
-  tags:
-    - skip_ansible_lint
-
-- name: Set systemd version fact
-  ansible.builtin.set_fact:
-    prometheus_systemd_version: "{{ __systemd_version.stdout_lines[0].split(' ')[-1] }}"
+- name: Gather package facts
+  ansible.builtin.package_facts:
+  when: "not 'packages' in ansible_facts"
 
 - name: Assert no duplicate config flags
   ansible.builtin.assert:

--- a/roles/prometheus/tasks/preflight.yml
+++ b/roles/prometheus/tasks/preflight.yml
@@ -40,7 +40,8 @@
 
 - name: Get all file_sd files from scrape_configs
   ansible.builtin.set_fact:
-    file_sd_files: "{{ prometheus_scrape_configs | selectattr('file_sd_configs', 'defined') | map(attribute='file_sd_configs') | flatten | map(attribute='files') | flatten }}"
+    file_sd_files: "{{ prometheus_scrape_configs | selectattr('file_sd_configs', 'defined') | map(attribute='file_sd_configs') |
+                    flatten | map(attribute='files') | flatten }}"
 
 - name: Fail when file_sd targets are not defined in scrape_configs
   ansible.builtin.fail:

--- a/roles/prometheus/templates/prometheus.service.j2
+++ b/roles/prometheus/templates/prometheus.service.j2
@@ -52,7 +52,7 @@ RemoveIPC=true
 RestrictSUIDSGID=true
 #SystemCallFilter=@signal @timer
 
-{% if prometheus_systemd_version | int >= 231 %}
+{% if (ansible_facts.packages.systemd | first).version is version('231', '>=') %}
 ReadWritePaths={{ prometheus_db_dir }}
 {% for path in prometheus_read_only_dirs %}
 ReadOnlyPaths={{ path }}
@@ -64,7 +64,7 @@ ReadOnlyDirectories={{ path }}
 {% endfor %}
 {% endif %}
 
-{% if prometheus_systemd_version | int >= 232 %}
+{% if (ansible_facts.packages.systemd | first).version is version('232', '>=') %}
 PrivateUsers=true
 ProtectControlGroups=true
 ProtectKernelModules=true


### PR DESCRIPTION
- Avoids using the command module and fragile regex parsing to get systemd version by getting systemd version from `package_facts`.
- This also removes the need for skipping the linting which caused the yaml linter to stop processing the rest of the preflight tasks, see bug: https://github.com/ansible/ansible-lint/issues/3139