### PR TITLE
enhancement: Check that TLS cert and key can be read

### DIFF
--- a/roles/node_exporter/tasks/preflight.yml
+++ b/roles/node_exporter/tasks/preflight.yml
@@ -41,7 +41,7 @@
         path: "{{ node_exporter_tls_server_config.cert_file }}"
       register: __node_exporter_cert_file
       become: true
-      become_user: "{{ _node_exporter_system_user }}"
+      become_user: "{{ node_exporter_system_user }}"
 
     - name: Check existence of TLS key file
       ansible.builtin.stat:

--- a/roles/node_exporter/tasks/preflight.yml
+++ b/roles/node_exporter/tasks/preflight.yml
@@ -62,7 +62,7 @@
           - "{{ __node_exporter_cert_file.stat.readable }}"
           - "{{ __node_exporter_key_file.stat.readable }}"
         msg: >-
-          {{ _node_exporter_system_user }} system user does not have read
+          {{ node_exporter_system_user }} system user does not have read
           permission on the TLS key and/or certificate.
 
 - name: Check if node_exporter is installed

--- a/roles/node_exporter/tasks/preflight.yml
+++ b/roles/node_exporter/tasks/preflight.yml
@@ -48,7 +48,7 @@
         path: "{{ node_exporter_tls_server_config.key_file }}"
       register: __node_exporter_key_file
       become: true
-      become_user: "{{ _node_exporter_system_user }}"
+      become_user: "{{ node_exporter_system_user }}"
 
     - name: Assert that TLS key and cert are present
       ansible.builtin.assert:

--- a/roles/node_exporter/tasks/preflight.yml
+++ b/roles/node_exporter/tasks/preflight.yml
@@ -40,17 +40,30 @@
       ansible.builtin.stat:
         path: "{{ node_exporter_tls_server_config.cert_file }}"
       register: __node_exporter_cert_file
+      become: true
+      become_user: "{{ _node_exporter_system_user }}"
 
     - name: Check existence of TLS key file
       ansible.builtin.stat:
         path: "{{ node_exporter_tls_server_config.key_file }}"
       register: __node_exporter_key_file
+      become: true
+      become_user: "{{ _node_exporter_system_user }}"
 
     - name: Assert that TLS key and cert are present
       ansible.builtin.assert:
         that:
           - "{{ __node_exporter_cert_file.stat.exists }}"
           - "{{ __node_exporter_key_file.stat.exists }}"
+
+    - name: Assert that node_exporter can read TLS key and cert
+      ansible.builtin.assert:
+        that:
+          - "{{ __node_exporter_cert_file.stat.readable }}"
+          - "{{ __node_exporter_key_file.stat.readable }}"
+        msg: >-
+          {{ _node_exporter_system_user }} system user does not have read
+          permission on the TLS key and/or certificate.
 
 - name: Check if node_exporter is installed
   ansible.builtin.stat:


### PR DESCRIPTION
## Summary

This pull request adds an extra assertion to the preflight checks to confirm that the `node_exporter` process has read permission on the TLS key and certificate.

## Background

When we tried setting up the node exporter with TLS we found that the playbook ran successfully but that the node exporter was not running on the target server.
The error messages from `systemctl status node_exporter` did not contain useful information.
Eventually we traced the problem to the TLS certificate having `r-------- root root` permissions and therefore not being accessible to the `node-exp` system account.
Adding this extra check will prevent this happening to others.

## To test

I have not updated the `molecule` tests as there were no equivalent tests on the other preflight assertions. To trigger the assertion manually, you can run `chmod 0000 /path/to/your/tls.key` and then apply the role. It should fail during the preflight tests.

Thank you for your work on this role!

Note: This merge request has been migrated from the previous repository at https://github.com/cloudalchemy/ansible-node-exporter/pull/264
