### PR TITLE
Disable line-length check in arguments_specs

### DIFF
--- a/roles/alertmanager/meta/argument_specs.yml
+++ b/roles/alertmanager/meta/argument_specs.yml
@@ -1,4 +1,5 @@
 ---
+# yamllint disable rule:line-length
 argument_specs:
   main:
     short_description: "Prometheus Alertmanager service"
@@ -17,8 +18,7 @@ argument_specs:
           - "This overrides I(alertmanager_version) parameter"
       alertmanager_binary_url:
         description: "URL of the alertmanager binaries .tar.gz file"
-        default: "https://github.com/prometheus/alertmanager/releases/download/v{{ alertmanager_version }}/\
-                  alertmanager-{{ alertmanager_version }}.linux-{{ go_arch }}.tar.gz"
+        default: "https://github.com/prometheus/alertmanager/releases/download/v{{ alertmanager_version }}/alertmanager-{{ alertmanager_version }}.linux-{{ go_arch }}.tar.gz"
       alertmanager_checksums_url:
         description: "URL of the alertmanager checksums file"
         default: "https://github.com/prometheus/alertmanager/releases/download/v{{ alertmanager_version }}/sha256sums.txt"

--- a/roles/blackbox_exporter/meta/argument_specs.yml
+++ b/roles/blackbox_exporter/meta/argument_specs.yml
@@ -1,4 +1,5 @@
 ---
+# yamllint disable rule:line-length
 argument_specs:
   main:
     short_description: "Deploy and manage Prometheus blackbox exporter"

--- a/roles/node_exporter/meta/argument_specs.yml
+++ b/roles/node_exporter/meta/argument_specs.yml
@@ -1,4 +1,5 @@
 ---
+# yamllint disable rule:line-length
 argument_specs:
   main:
     short_description: "Prometheus Node Exporter"
@@ -17,8 +18,7 @@ argument_specs:
           - "This overrides the I(node_exporter_version) parameter"
       node_exporter_binary_url:
         description: "URL of the node exporter binaries .tar.gz file"
-        default: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/\
-                  node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
+        default: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
       node_exporter_checksums_url:
         description: "URL of the node exporter checksums file"
         default: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/sha256sums.txt"

--- a/roles/prometheus/meta/argument_specs.yml
+++ b/roles/prometheus/meta/argument_specs.yml
@@ -1,4 +1,5 @@
 ---
+# yamllint disable rule:line-length
 argument_specs:
   main:
     short_description: "Installs and configures prometheus"
@@ -23,8 +24,7 @@ argument_specs:
           - "This overrides I(prometheus_version) parameter"
       prometheus_binary_url:
         description: "URL of the prometheus binaries .tar.gz file"
-        default: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/\
-                  prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
+        default: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/ prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
       prometheus_checksums_url:
         description: URL of the prometheus checksums file
         default: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/sha256sums.txt"
@@ -42,8 +42,7 @@ argument_specs:
         description: "Address on which prometheus will be listening"
         default: "0.0.0.0:9090"
       prometheus_web_config:
-        description: "A Prometheus L(web config yaml,https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md)
-                      for configuring TLS and auth."
+        description: "A Prometheus L(web config yaml,https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md) for configuring TLS and auth."
         type: "dict"
       prometheus_web_external_url:
         description: "External address on which prometheus is available. Useful when behind reverse proxy. Ex. `http://example.org/prometheus`"
@@ -68,21 +67,18 @@ argument_specs:
       prometheus_alertmanager_config:
         description:
           - "Configuration responsible for pointing where alertmanagers are. This should be specified as list in yaml format."
-          - "It is compatible with the official
-             L(alertmanager_config,https://prometheus.io/docs/prometheus/latest/configuration/configuration/#alertmanager_config)"
+          - "It is compatible with the official L(alertmanager_config,https://prometheus.io/docs/prometheus/latest/configuration/configuration/#alertmanager_config)"
         type: "list"
         elements: "str"
       prometheus_alert_relabel_configs:
         description:
           - "Alert relabeling rules. This should be specified as list in yaml format."
-          - "It is compatible with the official
-             L(alert_relabel_configs,https://prometheus.io/docs/prometheus/latest/configuration/configuration/#alert_relabel_configs)"
+          - "It is compatible with the official L(alert_relabel_configs,https://prometheus.io/docs/prometheus/latest/configuration/configuration/#alert_relabel_configs)"
         type: "list"
         elements: "str"
       prometheus_global:
         description:
-          - "Prometheus global config. It is compatible with the
-             L(official configuration,https://prometheus.io/docs/prometheus/latest/configuration/configuration/#configuration-file)"
+          - "Prometheus global config. It is compatible with the L(official configuration,https://prometheus.io/docs/prometheus/latest/configuration/configuration/#configuration-file)"
         type: "dict"
         default:
           scrape_interval: "60s"
@@ -90,14 +86,12 @@ argument_specs:
           evaluation_interval: "15s"
       prometheus_remote_write:
         description:
-          - "Remote write. Compatible with the
-             L(official configuration,https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write)"
+          - "Remote write. Compatible with the L(official configuration,https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write)"
         type: "list"
         elements: "str"
       prometheus_remote_read:
         description:
-          - "Remote read. It is compatible with the
-             L(official configuration,https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_read)"
+          - "Remote read. It is compatible with the L(official configuration,https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_read)"
         type: "list"
         elements: "str"
       prometheus_external_labels:
@@ -111,8 +105,7 @@ argument_specs:
         type: "dict"
       prometheus_scrape_configs:
         description:
-          - "Prometheus scrape jobs provided in same format as in the
-             L(official docs,https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config)"
+          - "Prometheus scrape jobs provided in same format as in the L(official docs,https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config)"
         type: "list"
         elements: "dict"
         default:
@@ -145,8 +138,7 @@ argument_specs:
           - "prometheus/rules/*.rules"
       prometheus_static_targets_files:
         description:
-          - "List of folders where ansible will look for files containing custom static target configuration files
-             which will be copied to C({{ prometheus_config_dir }}/file_sd/)."
+          - "List of folders where ansible will look for files containing custom static target configuration files which will be copied to C({{ prometheus_config_dir }}/file_sd/)."
         type: "list"
         elements: "str"
         default:

--- a/roles/snmp_exporter/meta/argument_specs.yml
+++ b/roles/snmp_exporter/meta/argument_specs.yml
@@ -1,4 +1,5 @@
 ---
+# yamllint disable rule:line-length
 argument_specs:
   main:
     short_description: "Prometheus SNMP exporter"
@@ -12,8 +13,7 @@ argument_specs:
         default: "0.19.0"
       snmp_exporter_binary_url:
         description: "URL of the snmp exporter binaries .tar.gz file"
-        default: "https://github.com/prometheus/snmp_exporter/releases/download/v{{ snmp_exporter_version }}/\
-                  snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
+        default: "https://github.com/prometheus/snmp_exporter/releases/download/v{{ snmp_exporter_version }}/snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
       snmp_exporter_checksums_url:
         description: "URL of the snmp exporter checksums file"
         default: "https://github.com/prometheus/snmp_exporter/releases/download/v{{ snmp_exporter_version }}/sha256sums.txt"


### PR DESCRIPTION
Allow long lines in the arguments_spec to avoid line wrapping. This allows the files to be processed with `yq` without constant diffs and errors.