### PR TITLE
New prometheus/prometheus upstream release!

### DIFF
--- a/roles/prometheus/README.md
+++ b/roles/prometheus/README.md
@@ -17,7 +17,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
-| `prometheus_version` | 2.27.0 | Prometheus package version. Also accepts `latest` as parameter. Only prometheus 2.x is supported |
+| `prometheus_version` | 2.42.0 | Prometheus package version. Also accepts `latest` as parameter. Only prometheus 2.x is supported |
 | `prometheus_skip_install` | false | Prometheus installation tasks gets skipped when set to true. |
 | `prometheus_binary_local_dir` | "" | Allows to use local packages instead of ones distributed on github. As parameter it takes a directory where `prometheus` AND `promtool` binaries are stored on host on which ansible is ran. This overrides `prometheus_version` parameter |
 | `prometheus_config_dir` | /etc/prometheus | Path to directory with prometheus configuration |

--- a/roles/prometheus/defaults/main.yml
+++ b/roles/prometheus/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-prometheus_version: 2.27.0
+prometheus_version: 2.42.0
 prometheus_binary_local_dir: ''
 prometheus_binary_url: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/\
                         prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"


### PR DESCRIPTION
The upstream [prometheus/prometheus](https://github.com/prometheus/prometheus) released new software version - **2.42.0**! This automated PR updates code to bring new version into repository.

## Commit Message
create [patch] release