### PR TITLE
fix: policycoreutils python package name

### DIFF
--- a/roles/alertmanager/tasks/selinux.yml
+++ b/roles/alertmanager/tasks/selinux.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install selinux python packages [RedHat]
   ansible.builtin.package:
-    name: "{{ ['libselinux-python', 'python-policycoreutils']
+    name: "{{ ['libselinux-python', 'policycoreutils-python']
            if ansible_python_version is version('3', '<') else
            ['python3-libselinux', 'python3-policycoreutils'] }}"
     state: present

--- a/roles/node_exporter/tasks/selinux.yml
+++ b/roles/node_exporter/tasks/selinux.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install selinux python packages [RedHat]
   ansible.builtin.package:
-    name: "{{ ['libselinux-python', 'python-policycoreutils']
+    name: "{{ ['libselinux-python', 'policycoreutils-python']
            if ansible_python_version is version('3', '<') else
            ['python3-libselinux', 'python3-policycoreutils'] }}"
     state: present

--- a/roles/prometheus/vars/main.yml
+++ b/roles/prometheus/vars/main.yml
@@ -9,6 +9,6 @@ go_arch_map:
 go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
 _prometheus_binary_install_dir: '/usr/local/bin'
 
-_prometheus_selinux_packages: "{{ ['libselinux-python', 'python-policycoreutils']
+_prometheus_selinux_packages: "{{ ['libselinux-python', 'policycoreutils-python']
                                if ansible_python_version is version('3', '<') else
                                ['python3-libselinux', 'python3-policycoreutils'] }}"


### PR DESCRIPTION
I have a few legacy hosts with Centos 7 where trying to install python-policycoreutils fails.

At least in Centos 7 the packages is named policycoreutils-python, and finding no such package here either https://pkgs.org/download/python-policycoreutils