### PR TITLE
refactor: underscore variable prefix should be reserved...

### DIFF
--- a/roles/node_exporter/defaults/main.yml
+++ b/roles/node_exporter/defaults/main.yml
@@ -26,7 +26,6 @@ node_exporter_enabled_collectors:
 
 node_exporter_disabled_collectors: []
 
-# Internal variables.
-_node_exporter_binary_install_dir: "/usr/local/bin"
-_node_exporter_system_group: "node-exp"
-_node_exporter_system_user: "{{ _node_exporter_system_group }}"
+node_exporter_binary_install_dir: "/usr/local/bin"
+node_exporter_system_group: "node-exp"
+node_exporter_system_user: "{{ node_exporter_system_group }}"

--- a/roles/node_exporter/meta/argument_specs.yml
+++ b/roles/node_exporter/meta/argument_specs.yml
@@ -62,3 +62,18 @@ argument_specs:
       node_exporter_basic_auth_users:
         description: "Dictionary of users and password for basic authentication. Passwords are automatically hashed with bcrypt."
         type: "dict"
+      node_exporter_binary_install_dir:
+        description:
+          - "I(Advanced)"
+          - "Directory to install node_exporter binary"
+        default: "/usr/local/bin"
+      node_exporter_system_group:
+        description:
+          - "I(Advanced)"
+          - "System group for node exporter"
+        default: "node-exp"
+      node_exporter_system_user:
+        description:
+          - "I(Advanced)"
+          - "Node exporter user"
+        default: "node-exp"

--- a/roles/node_exporter/tasks/configure.yml
+++ b/roles/node_exporter/tasks/configure.yml
@@ -35,8 +35,8 @@
   ansible.builtin.file:
     path: "{{ node_exporter_textfile_dir }}"
     state: directory
-    owner: "{{ _node_exporter_system_user }}"
-    group: "{{ _node_exporter_system_group }}"
+    owner: "{{ node_exporter_system_user }}"
+    group: "{{ node_exporter_system_group }}"
     recurse: true
     mode: u+rwX,g+rwX,o=rX
   when: node_exporter_textfile_dir | length > 0

--- a/roles/node_exporter/tasks/install.yml
+++ b/roles/node_exporter/tasks/install.yml
@@ -1,21 +1,21 @@
 ---
 - name: Create the node_exporter group
   ansible.builtin.group:
-    name: "{{ _node_exporter_system_group }}"
+    name: "{{ node_exporter_system_group }}"
     state: present
     system: true
-  when: _node_exporter_system_group != "root"
+  when: node_exporter_system_group != "root"
 
 - name: Create the node_exporter user
   ansible.builtin.user:
-    name: "{{ _node_exporter_system_user }}"
-    groups: "{{ _node_exporter_system_group }}"
+    name: "{{ node_exporter_system_user }}"
+    groups: "{{ node_exporter_system_group }}"
     append: true
     shell: /usr/sbin/nologin
     system: true
     create_home: false
     home: /
-  when: _node_exporter_system_user != "root"
+  when: node_exporter_system_user != "root"
 
 - name: Discover latest version
   when: node_exporter_binary_local_dir | length == 0
@@ -47,7 +47,7 @@
     - name: Propagate node_exporter binaries
       ansible.builtin.copy:
         src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}/node_exporter"
-        dest: "{{ _node_exporter_binary_install_dir }}/node_exporter"
+        dest: "{{ node_exporter_binary_install_dir }}/node_exporter"
         mode: 0755
         owner: root
         group: root
@@ -57,7 +57,7 @@
 - name: Propagate locally distributed node_exporter binary
   ansible.builtin.copy:
     src: "{{ node_exporter_binary_local_dir }}/node_exporter"
-    dest: "{{ _node_exporter_binary_install_dir }}/node_exporter"
+    dest: "{{ node_exporter_binary_install_dir }}/node_exporter"
     mode: 0755
     owner: root
     group: root

--- a/roles/node_exporter/tasks/preflight.yml
+++ b/roles/node_exporter/tasks/preflight.yml
@@ -54,14 +54,14 @@
 
 - name: Check if node_exporter is installed
   ansible.builtin.stat:
-    path: "{{ _node_exporter_binary_install_dir }}/node_exporter"
+    path: "{{ node_exporter_binary_install_dir }}/node_exporter"
   register: __node_exporter_is_installed
   check_mode: false
   tags:
     - node_exporter_install
 
 - name: Gather currently installed node_exporter version (if any)
-  ansible.builtin.command: "{{ _node_exporter_binary_install_dir }}/node_exporter --version"
+  ansible.builtin.command: "{{ node_exporter_binary_install_dir }}/node_exporter --version"
   changed_when: false
   register: __node_exporter_current_version_output
   check_mode: false

--- a/roles/node_exporter/templates/node_exporter.service.j2
+++ b/roles/node_exporter/templates/node_exporter.service.j2
@@ -6,9 +6,9 @@ After=network-online.target
 
 [Service]
 Type=simple
-User={{ _node_exporter_system_user }}
-Group={{ _node_exporter_system_group }}
-ExecStart={{ _node_exporter_binary_install_dir }}/node_exporter \
+User={{ node_exporter_system_user }}
+Group={{ node_exporter_system_group }}
+ExecStart={{ node_exporter_binary_install_dir }}/node_exporter \
 {% for collector in node_exporter_enabled_collectors -%}
 {%   if not collector is mapping %}
     --collector.{{ collector }} \


### PR DESCRIPTION
...for internal variables that are not user configurable

While it's not specified in any standard that I'm aware of, it's common that variables that are used internally in a role are prefixed with a underscore.

These variables were once not user configurable, so it makes sense that they were prefixed in the past, but I don't see any reason to keep them that way.