### PR TITLE
skip_changelog: Don't run CI on push

### DIFF
--- a/.github/workflows/ansible-ci.yml
+++ b/.github/workflows/ansible-ci.yml
@@ -1,9 +1,6 @@
 ---
 name: Ansible CI
 on:
-  push:
-    branches-ignore:
-      - main
   pull_request:
     types:
       - opened


### PR DESCRIPTION
Avoid running ansible-ci workflow on push, since it doubles the number of executions for PRs built on in-repo branches.