### PR TITLE
skip_changelog: Use prom image for version script

### DIFF
--- a/.github/workflows/version_bumper.yml
+++ b/.github/workflows/version_bumper.yml
@@ -13,12 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       role-repos: ${{ steps.discovered-role-repos.outputs.result }}
+    container:
+      image: quay.io/prometheus/golang-builder:base
     steps:
       - uses: actions/checkout@v3
 
       - name: Get repos for each role
         id: discovered-role-repos
-        uses: mikefarah/yq@master
         with:
           cmd: ./.github/scripts/discover_role_repos.sh
 


### PR DESCRIPTION
The yq image is just yq. Use the prometheus golang-builder image to get a proper shell and yq.