### PR TITLE
enhancement: add `skip_install` variables to various roles

### DIFF
--- a/roles/alertmanager/README.md
+++ b/roles/alertmanager/README.md
@@ -19,6 +19,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
 | `alertmanager_version` | 0.21.0 | Alertmanager package version. Also accepts `latest` as parameter. |
+| `alertmanager_skip_install` | false | Alertmanager installation tasks gets skipped when set to true. |
 | `alertmanager_binary_local_dir` | "" | Allows to use local packages instead of ones distributed on github. As parameter it takes a directory where `alertmanager` AND `amtool` binaries are stored on host on which ansible is ran. This overrides `alertmanager_version` parameter |
 | `alertmanager_binary_url` | `https://github.com/prometheus/alertmanager/releases/download/v{{ alertmanager_version }}/alertmanager-{{ alertmanager_version }}.linux-{{ go_arch }}.tar.gz` | URL of the alertmanager binaries .tar.gz file |
 | `alertmanager_checksums_url` | `https://github.com/prometheus/alertmanager/releases/download/v{{ alertmanager_version }}/sha256sums.txt` | URL of the alertmanager checksums file |

--- a/roles/alertmanager/defaults/main.yml
+++ b/roles/alertmanager/defaults/main.yml
@@ -4,6 +4,7 @@ alertmanager_binary_local_dir: ''
 alertmanager_binary_url: "https://github.com/{{ _alertmanager_repo }}/releases/download/v{{ alertmanager_version }}/\
                           alertmanager-{{ alertmanager_version }}.linux-{{ go_arch }}.tar.gz"
 alertmanager_checksums_url: "https://github.com/{{ _alertmanager_repo }}/releases/download/v{{ alertmanager_version }}/sha256sums.txt"
+alertmanager_skip_install: false
 
 alertmanager_config_dir: /etc/alertmanager
 alertmanager_db_dir: /var/lib/alertmanager

--- a/roles/alertmanager/meta/argument_specs.yml
+++ b/roles/alertmanager/meta/argument_specs.yml
@@ -11,6 +11,10 @@ argument_specs:
       alertmanager_version:
         description: "Alertmanager package version. Also accepts `latest` as parameter."
         default: 0.21.0
+      alertmanager_skip_install:
+        description: "Alertmanager installation tasks gets skipped when set to true."
+        type: bool
+        default: false
       alertmanager_binary_local_dir:
         description:
           - "Allows to use local packages instead of ones distributed on github."

--- a/roles/alertmanager/tasks/install.yml
+++ b/roles/alertmanager/tasks/install.yml
@@ -27,7 +27,9 @@
     - "{{ _alertmanager_amtool_config_dir }}"
 
 - name: Get alertmanager binary
-  when: alertmanager_binary_local_dir | length == 0
+  when:
+    - alertmanager_binary_local_dir | length == 0
+    - not alertmanager_skip_install
   block:
 
     - name: Download alertmanager binary to local folder
@@ -78,6 +80,8 @@
   with_items:
     - alertmanager
     - amtool
-  when: alertmanager_binary_local_dir | length > 0
+  when:
+    - alertmanager_binary_local_dir | length > 0
+    - not alertmanager_skip_install
   notify:
     - restart alertmanager

--- a/roles/alertmanager/tasks/preflight.yml
+++ b/roles/alertmanager/tasks/preflight.yml
@@ -29,10 +29,12 @@
   when:
     - alertmanager_version == "latest"
     - alertmanager_binary_local_dir | length == 0
+    - not alertmanager_skip_install
 
 - name: Get alertmanager binary checksum
   when:
     - alertmanager_binary_local_dir | length == 0
+    - not alertmanager_skip_install
   block:
     - name: "Get checksum list"
       ansible.builtin.set_fact:

--- a/roles/blackbox_exporter/README.md
+++ b/roles/blackbox_exporter/README.md
@@ -18,6 +18,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
 | `blackbox_exporter_version` | 0.18.0 | Blackbox exporter package version |
+| `blackbox_exporter_skip_install` | false | Blackbox exporter installation tasks gets skipped when set to true. |
 | `blackbox_exporter_binary_url` | `"https://github.com/prometheus/blackbox_exporter/releases/download/v{{ blackbox_exporter_version }}/blackbox_exporter-{{ blackbox_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"` | URL of the blackbox exporter binaries .tar.gz file |
 | `blackbox_exporter_web_listen_address` | 0.0.0.0:9115 | Address on which blackbox exporter will be listening |
 | `blackbox_exporter_cli_flags` | {} | Additional configuration flags passed to blackbox exporter binary at startup |

--- a/roles/blackbox_exporter/defaults/main.yml
+++ b/roles/blackbox_exporter/defaults/main.yml
@@ -3,6 +3,7 @@ blackbox_exporter_version: 0.18.0
 blackbox_exporter_binary_url: "https://github.com/{{ _blackbox_exporter_repo }}/releases/download/v{{ blackbox_exporter_version }}/\
                                blackbox_exporter-{{ blackbox_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] |
                                default(ansible_architecture) }}.tar.gz"
+blackbox_exporter_skip_install: false
 
 blackbox_exporter_web_listen_address: "0.0.0.0:9115"
 

--- a/roles/blackbox_exporter/meta/argument_specs.yml
+++ b/roles/blackbox_exporter/meta/argument_specs.yml
@@ -11,6 +11,10 @@ argument_specs:
       blackbox_exporter_version:
         description: "Blackbox exporter package version"
         default: "0.18.0"
+      blackbox_exporter_skip_install:
+        description: "Blackbox exporter installation tasks gets skipped when set to true."
+        type: bool
+        default: false
       blackbox_exporter_binary_url:
         description: "URL of the blackbox_exporter binaries .tar.gz file"
         default: "https://github.com/{{ _blackbox_exporter_repo }}/releases/download/v{{ blackbox_exporter_version }}/blackbox_exporter-{{ blackbox_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"

--- a/roles/blackbox_exporter/tasks/install.yml
+++ b/roles/blackbox_exporter/tasks/install.yml
@@ -27,6 +27,7 @@
   delay: 2
   delegate_to: localhost
   check_mode: false
+  when: not blackbox_exporter_skip_install
 
 - name: Propagate blackbox exporter binary
   ansible.builtin.copy:
@@ -36,6 +37,7 @@
     mode: 0750
     owner: blackbox-exp
     group: blackbox-exp
+  when: not blackbox_exporter_skip_install
   notify:
     - restart blackbox exporter
 

--- a/roles/blackbox_exporter/tasks/preflight.yml
+++ b/roles/blackbox_exporter/tasks/preflight.yml
@@ -4,7 +4,7 @@
     that: ansible_service_mgr == 'systemd'
     msg: "This role only works with systemd"
 
-- name: Install package fact dependencie
+- name: Install package fact dependencies
   ansible.builtin.package:
     name: "{{ _pkg_fact_req }}"
     state: present

--- a/roles/mysqld_exporter/README.md
+++ b/roles/mysqld_exporter/README.md
@@ -18,6 +18,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
 | `mysqld_exporter_version` | 0.14.0 | mysqld exporter package version. Also accepts latest as parameter. |
+| `mysqld_exporter_skip_install` | false | mysqld exporter installation tasks gets skipped when set to true. |
 | `mysqld_exporter_binary_local_dir` | "" | Enables the use of local packages instead of those distributed on github. The parameter may be set to a directory where the `mysqld_exporter` binary is stored on the host where ansible is run. This overrides the `mysqld_exporter_version` parameter |
 | `mysqld_exporter_binary_url` | `https://github.com/prometheus/mysqld_exporter/releases/download/v{{ mysqld_exporter_version }}/mysqld_exporter-{{ mysqld_exporter_version }}.linux-{{ go_arch }}.tar.gz` | URL of the mysqld\_exporter binaries .tar.gz file |
 | `mysqld_exporter_checksums_url` | `https://github.com/prometheus/mysqld_exporter/releases/download/v{{ mysqld_exporter_version }}/sha256sums.txt` | URL of the mysqld\_exporter checksums file |

--- a/roles/mysqld_exporter/defaults/main.yml
+++ b/roles/mysqld_exporter/defaults/main.yml
@@ -4,6 +4,7 @@ mysqld_exporter_binary_local_dir: ""
 mysqld_exporter_binary_url: "https://github.com/{{ _mysqld_exporter_repo }}/releases/download/v{{ mysqld_exporter_version }}/\
                            mysqld_exporter-{{ mysqld_exporter_version }}.linux-{{ go_arch }}.tar.gz"
 mysqld_exporter_checksums_url: "https://github.com/{{ _mysqld_exporter_repo }}/releases/download/v{{ mysqld_exporter_version }}/sha256sums.txt"
+mysqld_exporter_skip_install: false
 
 mysqld_exporter_web_listen_address: "0.0.0.0:9104"
 mysqld_exporter_web_telemetry_path: "/metrics"

--- a/roles/mysqld_exporter/meta/argument_specs.yml
+++ b/roles/mysqld_exporter/meta/argument_specs.yml
@@ -11,6 +11,10 @@ argument_specs:
       mysqld_exporter_version:
         description: "MySQLd exporter package version. Also accepts latest as parameter."
         default: "1.1.2"
+      mysqld_exporter_skip_install:
+        description: "MySQLd installation tasks gets skipped when set to true."
+        type: bool
+        default: false
       mysqld_exporter_binary_local_dir:
         description:
           - "Enables the use of local packages instead of those distributed on github."

--- a/roles/mysqld_exporter/tasks/install.yml
+++ b/roles/mysqld_exporter/tasks/install.yml
@@ -18,7 +18,9 @@
   when: mysqld_exporter_system_user != "root"
 
 - name: Discover latest version
-  when: mysqld_exporter_binary_local_dir | length == 0
+  when:
+    - mysqld_exporter_binary_local_dir | length == 0
+    - not mysqld_exporter_skip_install
   block:
 
     - name: Download mysqld_exporter binary to local folder
@@ -61,5 +63,7 @@
     mode: 0755
     owner: root
     group: root
-  when: mysqld_exporter_binary_local_dir | length > 0
+  when:
+    - mysqld_exporter_binary_local_dir | length > 0
+    - not mysqld_exporter_skip_install
   notify: restart mysqld_exporter

--- a/roles/mysqld_exporter/tasks/preflight.yml
+++ b/roles/mysqld_exporter/tasks/preflight.yml
@@ -82,9 +82,12 @@
   when:
     - mysqld_exporter_version == "latest"
     - mysqld_exporter_binary_local_dir | length == 0
+    - not mysqld_exporter_skip_install
 
 - name: Get mysqld_exporter binary checksum
-  when: mysqld_exporter_binary_local_dir | length == 0
+  when:
+    - mysqld_exporter_binary_local_dir | length == 0
+    - not mysqld_exporter_skip_install
   block:
     - name: Get checksum list from github
       ansible.builtin.set_fact:

--- a/roles/node_exporter/README.md
+++ b/roles/node_exporter/README.md
@@ -19,6 +19,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
 | `node_exporter_version` | 1.1.2 | Node exporter package version. Also accepts `latest` as parameter. |
+| `node_exporter_skip_install` | false | Node exporter installation tasks gets skipped when set to true. |
 | `node_exporter_binary_local_dir` | "" | Enables the use of local packages instead of those distributed on github. The parameter may be set to a directory where the `node_exporter` binary is stored on the host where ansible is run. This overrides the `node_exporter_version` parameter |
 | `node_exporter_binary_url` | `https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz` | URL of the node exporter binaries .tar.gz file |
 | `node_exporter_checksums_url` | `https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/sha256sums.txt` | URL of the node exporter checksums file |

--- a/roles/node_exporter/defaults/main.yml
+++ b/roles/node_exporter/defaults/main.yml
@@ -4,6 +4,7 @@ node_exporter_binary_local_dir: ""
 node_exporter_binary_url: "https://github.com/{{ _node_exporter_repo }}/releases/download/v{{ node_exporter_version }}/\
                            node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
 node_exporter_checksums_url: "https://github.com/{{ _node_exporter_repo }}/releases/download/v{{ node_exporter_version }}/sha256sums.txt"
+node_exporter_skip_install: false
 
 node_exporter_web_listen_address: "0.0.0.0:9100"
 node_exporter_web_telemetry_path: "/metrics"

--- a/roles/node_exporter/meta/argument_specs.yml
+++ b/roles/node_exporter/meta/argument_specs.yml
@@ -11,6 +11,10 @@ argument_specs:
       node_exporter_version:
         description: "Node exporter package version. Also accepts latest as parameter."
         default: "1.1.2"
+      node_exporter_skip_install:
+        description: "Node exporter installation tasks gets skipped when set to true."
+        type: bool
+        default: false
       node_exporter_binary_local_dir:
         description:
           - "Enables the use of local packages instead of those distributed on github."

--- a/roles/node_exporter/tasks/install.yml
+++ b/roles/node_exporter/tasks/install.yml
@@ -18,7 +18,9 @@
   when: node_exporter_system_user != "root"
 
 - name: Discover latest version
-  when: node_exporter_binary_local_dir | length == 0
+  when:
+    - node_exporter_binary_local_dir | length == 0
+    - not node_exporter_skip_install
   block:
 
     - name: Download node_exporter binary to local folder
@@ -61,5 +63,7 @@
     mode: 0755
     owner: root
     group: root
-  when: node_exporter_binary_local_dir | length > 0
+  when:
+    - node_exporter_binary_local_dir | length > 0
+    - not node_exporter_skip_install
   notify: restart node_exporter

--- a/roles/node_exporter/tasks/preflight.yml
+++ b/roles/node_exporter/tasks/preflight.yml
@@ -82,9 +82,12 @@
   when:
     - node_exporter_version == "latest"
     - node_exporter_binary_local_dir | length == 0
+    - not node_exporter_skip_install
 
 - name: Get node_exporter binary checksum
-  when: node_exporter_binary_local_dir | length == 0
+  when:
+    - node_exporter_binary_local_dir | length == 0
+    - not node_exporter_skip_install
   block:
     - name: Get checksum list from github
       ansible.builtin.set_fact:

--- a/roles/snmp_exporter/README.md
+++ b/roles/snmp_exporter/README.md
@@ -17,6 +17,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
 | `snmp_exporter_version` | 0.19.0 | SNMP exporter package version |
+| `snmp_exporter_skip_install` | false | SNMP exporter installation tasks gets skipped when set to true. |
 | `snmp_exporter_binary_url` | `https://github.com/prometheus/snmp_exporter/releases/download/v{{ snmp_exporter_version }}/snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz` | URL of the snmp exporter binaries .tar.gz file |
 | `snmp_exporter_checksums_url` | `https://github.com/prometheus/snmp_exporter/releases/download/v{{ snmp_exporter_version }}/sha256sums.txt` | URL of the snmp exporter checksums file |
 | `snmp_exporter_web_listen_address` | "0.0.0.0:9116" | Address on which SNMP exporter will be listening |

--- a/roles/snmp_exporter/defaults/main.yml
+++ b/roles/snmp_exporter/defaults/main.yml
@@ -3,6 +3,7 @@ snmp_exporter_version: 0.19.0
 snmp_exporter_binary_url: "https://github.com/{{ _snmp_exporter_repo }}/releases/download/v{{ snmp_exporter_version }}/\
                            snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
 snmp_exporter_checksums_url: "https://github.com/{{ _snmp_exporter_repo }}/releases/download/v{{ snmp_exporter_version }}/sha256sums.txt"
+snmp_exporter_skip_install: false
 snmp_exporter_web_listen_address: "0.0.0.0:9116"
 snmp_exporter_log_level: info
 

--- a/roles/snmp_exporter/meta/argument_specs.yml
+++ b/roles/snmp_exporter/meta/argument_specs.yml
@@ -11,6 +11,10 @@ argument_specs:
       snmp_exporter_version:
         description: "SNMP exporter package version"
         default: "0.19.0"
+      snmp_exporter_skip_install:
+        description: "SNMP exporter installation tasks gets skipped when set to true."
+        type: bool
+        default: false
       snmp_exporter_binary_url:
         description: "URL of the snmp exporter binaries .tar.gz file"
         default: "https://github.com/{{ _snmp_exporter_repo }}/releases/download/v{{ snmp_exporter_version }}/snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"

--- a/roles/snmp_exporter/tasks/install.yml
+++ b/roles/snmp_exporter/tasks/install.yml
@@ -12,6 +12,7 @@
   delay: 2
   delegate_to: localhost
   check_mode: false
+  when: not snmp_exporter_skip_install
 
 - name: Unpack snmp_exporter binary
   become: false
@@ -21,12 +22,14 @@
     creates: "/tmp/snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/snmp_exporter"
   delegate_to: localhost
   check_mode: false
+  when: not snmp_exporter_skip_install
 
 - name: Propagate SNMP Exporter binaries
   ansible.builtin.copy:
     src: "/tmp/snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/snmp_exporter"
     dest: "/usr/local/bin/snmp_exporter"
     mode: 0755
+  when: not snmp_exporter_skip_install
   notify:
     - restart snmp exporter
 

--- a/roles/snmp_exporter/tasks/preflight.yml
+++ b/roles/snmp_exporter/tasks/preflight.yml
@@ -4,4 +4,6 @@
     snmp_exporter_checksum: "{{ item.split(' ')[0] }}"
   with_items:
     - "{{ lookup('url', snmp_exporter_checksums_url, wantlist=True) | list }}"
-  when: "('linux-' + (go_arch_map[ansible_architecture] | default(ansible_architecture)) + '.tar.gz') in item"
+  when:
+    - "('linux-' + (go_arch_map[ansible_architecture] | default(ansible_architecture)) + '.tar.gz') in item"
+    - not snmp_exporter_skip_install

--- a/roles/systemd_exporter/README.md
+++ b/roles/systemd_exporter/README.md
@@ -18,6 +18,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
 | `systemd_exporter_version` | 0.4.0 | SystemD exporter package version. Also accepts latest as parameter. |
+| `systemd_exporter_skip_install` | false | SystemD exporter installation tasks gets skipped when set to true. |
 | `systemd_exporter_binary_local_dir` | "" | Allows to use local packages instead of ones distributed on github. As parameter it takes a directory where `systemd_exporter` binary is stored on host on which ansible is ran. This overrides `systemd_exporter_version` parameter |
 | `systemd_exporter_binary_url` | `https://github.com/prometheus-community/systemd_exporter/releases/download/v{{ systemd_exporter_version }}/systemd_exporter-{{ systemd_exporter_version }}.linux-{{ go_arch }}.tar.gz` | URL of the systemd exporter binaries .tar.gz file |
 | `systemd_exporter_checksums_url` | `https://github.com/prometheus-community/systemd_exporter/releases/download/v{{ systemd_exporter_version }}/sha256sums.txt` | URL of the systemd exporter checksums file |

--- a/roles/systemd_exporter/defaults/main.yml
+++ b/roles/systemd_exporter/defaults/main.yml
@@ -4,6 +4,7 @@ systemd_exporter_binary_local_dir: ""
 systemd_exporter_binary_url: "https://github.com/{{ _systemd_exporter_repo }}/releases/download/v{{ systemd_exporter_version }}/\
                                     systemd_exporter-{{ systemd_exporter_version }}.linux-{{ go_arch }}.tar.gz"
 systemd_exporter_checksums_url: "https://github.com/{{ _systemd_exporter_repo }}/releases/download/v{{ systemd_exporter_version }}/sha256sums.txt"
+systemd_exporter_skip_install: false
 systemd_exporter_web_listen_address: "0.0.0.0:9558"
 
 systemd_exporter_enable_restart_count: false

--- a/roles/systemd_exporter/meta/argument_specs.yml
+++ b/roles/systemd_exporter/meta/argument_specs.yml
@@ -11,6 +11,10 @@ argument_specs:
       systemd_exporter_version:
         description: "SystemD exporter package version. Also accepts latest as parameter."
         default: "0.4.0"
+      systemd_exporter_skip_install:
+        description: "SystemD exporter installation tasks gets skipped when set to true."
+        type: bool
+        default: false
       systemd_exporter_binary_local_dir:
         description:
           - "Allows to use local packages instead of ones distributed on github."

--- a/roles/systemd_exporter/tasks/install.yml
+++ b/roles/systemd_exporter/tasks/install.yml
@@ -18,7 +18,9 @@
   when: systemd_exporter_system_user != "root"
 
 - name: Get systemd exporter binary
-  when: systemd_exporter_binary_local_dir | length == 0
+  when:
+    - systemd_exporter_binary_local_dir | length == 0
+    - not systemd_exporter_skip_install
   block:
     - name: Download systemd_exporter binary to local folder
       become: false
@@ -60,5 +62,7 @@
     mode: 0755
     owner: root
     group: root
-  when: systemd_exporter_binary_local_dir | length > 0
+  when:
+    - systemd_exporter_binary_local_dir | length > 0
+    - not systemd_exporter_skip_install
   notify: restart systemd_exporter

--- a/roles/systemd_exporter/tasks/preflight.yml
+++ b/roles/systemd_exporter/tasks/preflight.yml
@@ -64,9 +64,12 @@
   when:
     - systemd_exporter_version == "latest"
     - systemd_exporter_binary_local_dir | length == 0
+    - not systemd_exporter_skip_install
 
 - name: Get systemd exporter binary checksum
-  when: systemd_exporter_binary_local_dir | length == 0
+  when:
+    - systemd_exporter_binary_local_dir | length == 0
+    - not systemd_exporter_skip_install
   block:
     - name: Get checksum list from github
       ansible.builtin.set_fact:


### PR DESCRIPTION
This is similar to prometheus_skip_install variable and does what the name says: when set, it won't try to re-download alertmanager binaries

thanks for considering