### PR TITLE
skip_changelog: remove extra spaces in url

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -31,8 +31,9 @@ jobs:
       init-html-short-title: Prometheus.Prometheus Collection Docs
       init-extra-html-theme-options: |
         documentation_home_url=https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/branch/main/
-      render-file-line: '> * `$<status>` [$<path_tail>](https://${{ github.repository_owner }}.github.io/\
-                         ${{ github.event.repository.name }}/pr/${{ github.event.number }}/$<path_tail>)'
+      render-file-line:
+        '> * `$<status>`
+         [$<path_tail>](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr/${{ github.event.number }}/$<path_tail>)'
 
   publish-docs-gh-pages:
     # for now we won't run this on forks


### PR DESCRIPTION
Should remove extra spaces in the urls of docs PR comments, such as this one:

> * `M` [alertmanager_role.html](https://prometheus-community.github.io/\ ansible/pr/74/alertmanager_role.html)