### PR TITLE
feat: allow to set `node_exporter_textfile_dir` to `false`

### DIFF
--- a/roles/node_exporter/tasks/configure.yml
+++ b/roles/node_exporter/tasks/configure.yml
@@ -39,7 +39,7 @@
     group: "{{ node_exporter_system_group }}"
     recurse: true
     mode: u+rwX,g+rwX,o=rX
-  when: node_exporter_textfile_dir | length > 0
+  when: node_exporter_textfile_dir and node_exporter_textfile_dir | length > 0
 
 - name: Allow node_exporter port in SELinux on RedHat OS family
   community.general.seport:


### PR DESCRIPTION
It would be nice to have an opportunity to set `node_exporter_textfile_dir` to `false` or `no` in case I want to disable the collector. E.g.

```yml
- name: Install & configure node_exporter
  ansible.builtin.include_role:
    name: setup_node_exporter
  vars:
    node_exporter_version: 'latest'
    node_exporter_textfile_dir: no
```