### PR TITLE
enhancement: support ansible-vaulted basic auth passwords

### DIFF
--- a/roles/mysqld_exporter/templates/web_config.yaml.j2
+++ b/roles/mysqld_exporter/templates/web_config.yaml.j2
@@ -13,6 +13,6 @@ http_server_config:
 {% if mysqld_exporter_basic_auth_users | length > 0 %}
 basic_auth_users:
 {% for k, v in mysqld_exporter_basic_auth_users.items() %}
-  {{ k }}: {{ v | password_hash('bcrypt', ('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890' | shuffle(seed=inventory_hostname) | join)[:22], rounds=9) }}
+  {{ k }}: {{ v | string | password_hash('bcrypt', ('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890' | shuffle(seed=inventory_hostname) | join)[:22], rounds=9) }}
 {% endfor %}
 {% endif %}

--- a/roles/node_exporter/templates/config.yaml.j2
+++ b/roles/node_exporter/templates/config.yaml.j2
@@ -13,6 +13,6 @@ http_server_config:
 {% if node_exporter_basic_auth_users | length > 0 %}
 basic_auth_users:
 {% for k, v in node_exporter_basic_auth_users.items() %}
-  {{ k }}: {{ v | password_hash('bcrypt', ('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890' | shuffle(seed=inventory_hostname) | join)[:22], rounds=9) }}
+  {{ k }}: {{ v | string | password_hash('bcrypt', ('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890' | shuffle(seed=inventory_hostname) | join)[:22], rounds=9) }}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
If ansible-vaulted password is passed to password_hash filter, it will throw and error: 'secret must be unicode or bytes, not ansible.parsing.yaml.objects.AnsibleVaultEncryptedUnicode' Handling the vaulted password with string filter first will avoid the problem.