### PR TITLE
docs: avoid maintaining variable documentation in many places

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# ansible
+# prometheus.prometheus
 Ansible Collection for Prometheus
+
+Documentation: https://prometheus-community.github.io/ansible/

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -21,7 +21,7 @@ tags:
 dependencies:
   community.general: '>=1.0.0'
 repository: "https://github.com/prometheus-community/ansible"
-documentation: "https://github.com/prometheus-community/ansible/blob/main/docs"
+documentation: "https://prometheus-community.github.io/ansible"
 homepage: "https://prometheus.io"
 issues: "https://github.com/prometheus-community/ansible/issues"
 build_ignore:

--- a/roles/alertmanager/README.md
+++ b/roles/alertmanager/README.md
@@ -14,43 +14,8 @@ It would be nice to have prometheus installed somewhere
 
 ## Role Variables
 
-All variables which can be overridden are stored in [defaults/main.yml](defaults/main.yml) file as well as in table below.
-
-| Name           | Default Value | Description                        |
-| -------------- | ------------- | -----------------------------------|
-| `alertmanager_version` | 0.21.0 | Alertmanager package version. Also accepts `latest` as parameter. |
-| `alertmanager_skip_install` | false | Alertmanager installation tasks gets skipped when set to true. |
-| `alertmanager_binary_local_dir` | "" | Allows to use local packages instead of ones distributed on github. As parameter it takes a directory where `alertmanager` AND `amtool` binaries are stored on host on which ansible is ran. This overrides `alertmanager_version` parameter |
-| `alertmanager_binary_url` | `https://github.com/prometheus/alertmanager/releases/download/v{{ alertmanager_version }}/alertmanager-{{ alertmanager_version }}.linux-{{ go_arch }}.tar.gz` | URL of the alertmanager binaries .tar.gz file |
-| `alertmanager_checksums_url` | `https://github.com/prometheus/alertmanager/releases/download/v{{ alertmanager_version }}/sha256sums.txt` | URL of the alertmanager checksums file |
-| `alertmanager_web_listen_address` | 0.0.0.0:9093 | Address on which alertmanager will be listening |
-| `alertmanager_web_external_url` | http://localhost:9093/ | External address on which alertmanager is available. Useful when behind reverse proxy. Ex. example.org/alertmanager |
-| `alertmanager_config_dir` | /etc/alertmanager | Path to directory with alertmanager configuration |
-| `alertmanager_db_dir` | /var/lib/alertmanager | Path to directory with alertmanager database |
-| `alertmanager_config_file` | alertmanager.yml.j2 | Variable used to provide custom alertmanager configuration file in form of ansible template |
-| `alertmanager_config_flags_extra` | {} | Additional configuration flags passed to prometheus binary at startup |
-| `alertmanager_template_files` | ['alertmanager/templates/*.tmpl'] | List of folders where ansible will look for template files which will be copied to `{{ alertmanager_config_dir }}/templates/`. Files must have `*.tmpl` extension |
-| `alertmanager_resolve_timeout` | 3m | Time after which an alert is declared resolved |
-| `alertmanager_smtp` | {} | SMTP (email) configuration |
-| `alertmanager_http_config` | {} | Http config for using custom webhooks |
-| `alertmanager_slack_api_url` | "" | Slack webhook url |
-| `alertmanager_pagerduty_url` | "" | Pagerduty webhook url |
-| `alertmanager_opsgenie_api_key` | "" | Opsgenie webhook key |
-| `alertmanager_opsgenie_api_url` | "" | Opsgenie webhook url |
-| `alertmanager_victorops_api_key` | "" | VictorOps webhook key |
-| `alertmanager_victorops_api_url` | "" | VictorOps webhook url |
-| `alertmanager_hipchat_api_url` | "" | Hipchat webhook url |
-| `alertmanager_hipchat_auth_token` | "" | Hipchat authentication token |
-| `alertmanager_wechat_url` | "" | Enterprise WeChat webhook url |
-| `alertmanager_wechat_secret` | "" | Enterprise WeChat secret token |
-| `alertmanager_wechat_corp_id` | "" | Enterprise WeChat corporation id |
-| `alertmanager_cluster` | {listen-address: ""} | HA cluster network configuration. Disabled by default. More information in [alertmanager readme](https://github.com/prometheus/alertmanager#high-availability) |
-| `alertmanager_receivers` | [] | A list of notification receivers. Configuration same as in [official docs](https://prometheus.io/docs/alerting/configuration/#<receiver>) |
-| `alertmanager_inhibit_rules` | [] | List of inhibition rules. Same as in [official docs](https://prometheus.io/docs/alerting/configuration/#inhibit_rule) |
-| `alertmanager_route` | {} | Alert routing. More in [official docs](https://prometheus.io/docs/alerting/configuration/#<route>) |
-| `alertmanager_amtool_config_file` | amtool.yml.j2 | Template for amtool config |
-| `alertmanager_amtool_config_alertmanager_url` | `alertmanager_web_external_url` | URL of the alertmanager |
-| `alertmanager_amtool_config_output` | extended | Extended output, use `""` for simple output. |
+All variables which can be overridden are stored in [defaults/main.yml](defaults/main.yml) file as well as in [meta/argument_specs.yml](meta/argument_specs.yml).
+Please refer to the [collection docs](https://prometheus-community.github.io/ansible/branch/main/alertmanager_role.html) for description and default values of the variables.
 
 ## Example
 

--- a/roles/blackbox_exporter/README.md
+++ b/roles/blackbox_exporter/README.md
@@ -13,16 +13,8 @@ Deploy and manage [blackbox exporter](https://github.com/prometheus/blackbox_exp
 
 ## Role Variables
 
-All variables which can be overridden are stored in [defaults/main.yml](defaults/main.yml) file as well as in table below.
-
-| Name           | Default Value | Description                        |
-| -------------- | ------------- | -----------------------------------|
-| `blackbox_exporter_version` | 0.18.0 | Blackbox exporter package version |
-| `blackbox_exporter_skip_install` | false | Blackbox exporter installation tasks gets skipped when set to true. |
-| `blackbox_exporter_binary_url` | `"https://github.com/prometheus/blackbox_exporter/releases/download/v{{ blackbox_exporter_version }}/blackbox_exporter-{{ blackbox_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"` | URL of the blackbox exporter binaries .tar.gz file |
-| `blackbox_exporter_web_listen_address` | 0.0.0.0:9115 | Address on which blackbox exporter will be listening |
-| `blackbox_exporter_cli_flags` | {} | Additional configuration flags passed to blackbox exporter binary at startup |
-| `blackbox_exporter_configuration_modules` | http_2xx: { prober: http, timeout: 5s, http: '' } | |
+All variables which can be overridden are stored in [defaults/main.yml](defaults/main.yml) file as well as in [meta/argument_specs.yml](meta/argument_specs.yml).
+Please refer to the [collection docs](https://prometheus-community.github.io/ansible/branch/main/blackbox_exporter_role.html) for description and default values of the variables.
 
 ## Example
 

--- a/roles/mysqld_exporter/README.md
+++ b/roles/mysqld_exporter/README.md
@@ -12,23 +12,8 @@ Deploy prometheus [mysql exporter](https://github.com/prometheus/mysqld_exporter
 - Passlib is required when using the basic authentication feature (`pip install passlib[bcrypt]`)
 
 ## Role Variables
-
-All variables which can be overridden are stored in [defaults/main.yml](defaults/main.yml) and are listed in the table below.
-
-| Name           | Default Value | Description                        |
-| -------------- | ------------- | -----------------------------------|
-| `mysqld_exporter_version` | 0.14.0 | mysqld exporter package version. Also accepts latest as parameter. |
-| `mysqld_exporter_skip_install` | false | mysqld exporter installation tasks gets skipped when set to true. |
-| `mysqld_exporter_binary_local_dir` | "" | Enables the use of local packages instead of those distributed on github. The parameter may be set to a directory where the `mysqld_exporter` binary is stored on the host where ansible is run. This overrides the `mysqld_exporter_version` parameter |
-| `mysqld_exporter_binary_url` | `https://github.com/prometheus/mysqld_exporter/releases/download/v{{ mysqld_exporter_version }}/mysqld_exporter-{{ mysqld_exporter_version }}.linux-{{ go_arch }}.tar.gz` | URL of the mysqld\_exporter binaries .tar.gz file |
-| `mysqld_exporter_checksums_url` | `https://github.com/prometheus/mysqld_exporter/releases/download/v{{ mysqld_exporter_version }}/sha256sums.txt` | URL of the mysqld\_exporter checksums file |
-| `mysqld_exporter_web_listen_address` | "0.0.0.0:9104" | Address on which mysqld\_exporter will listen |
-| `mysqld_exporter_web_telemetry_path` | "/metrics" | Path under which to expose metrics |
-| `mysqld_exporter_enabled_collectors` | `[]` | List of dicts defining additionally enabled collectors and their configuration. It adds collectors to [those enabled by default](https://github.com/prometheus/mysqld_exporter#collector-flags). |
-| `mysqld_exporter_disabled_collectors` | [] | List of disabled collectors. By default mysqld_exporter disables collectors listed [here](https://github.com/prometheus/mysqld_exporter#collector-flags). |
-| `mysqld_exporter_tls_server_config` | {} | Configuration for TLS authentication. Keys and values are the same as in [mysqld_exporter docs](https://github.com/prometheus/mysqld_exporter/blob/master/https/README.md#sample-config). |
-| `mysqld_exporter_http_server_config` | {} | Config for HTTP/2 support. Keys and values are the same as in [mysqld_exporter docs](https://github.com/prometheus/mysqld_exporter/blob/master/https/README.md#sample-config). |
-| `mysqld_exporter_basic_auth_users` | {} | Dictionary of users and password for basic authentication. Passwords are automatically hashed with bcrypt. |
+All variables which can be overridden are stored in [defaults/main.yml](defaults/main.yml) file as well as in [meta/argument_specs.yml](meta/argument_specs.yml).
+Please refer to the [collection docs](https://prometheus-community.github.io/ansible/branch/main/mysqld_exporter_role.html) for description and default values of the variables.
 
 ## Example
 

--- a/roles/node_exporter/README.md
+++ b/roles/node_exporter/README.md
@@ -14,23 +14,8 @@ Deploy prometheus [node exporter](https://github.com/prometheus/node_exporter) u
 
 ## Role Variables
 
-All variables which can be overridden are stored in [defaults/main.yml](defaults/main.yml) and are listed in the table below.
-
-| Name           | Default Value | Description                        |
-| -------------- | ------------- | -----------------------------------|
-| `node_exporter_version` | 1.1.2 | Node exporter package version. Also accepts `latest` as parameter. |
-| `node_exporter_skip_install` | false | Node exporter installation tasks gets skipped when set to true. |
-| `node_exporter_binary_local_dir` | "" | Enables the use of local packages instead of those distributed on github. The parameter may be set to a directory where the `node_exporter` binary is stored on the host where ansible is run. This overrides the `node_exporter_version` parameter |
-| `node_exporter_binary_url` | `https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz` | URL of the node exporter binaries .tar.gz file |
-| `node_exporter_checksums_url` | `https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/sha256sums.txt` | URL of the node exporter checksums file |
-| `node_exporter_web_listen_address` | "0.0.0.0:9100" | Address on which node exporter will listen |
-| `node_exporter_web_telemetry_path` | "/metrics" | Path under which to expose metrics |
-| `node_exporter_enabled_collectors` | ```["systemd",{textfile: {directory: "{{node_exporter_textfile_dir}}"}}]``` | List of dicts defining additionally enabled collectors and their configuration. It adds collectors to [those enabled by default](https://github.com/prometheus/node_exporter#enabled-by-default). |
-| `node_exporter_disabled_collectors` | [] | List of disabled collectors. By default node_exporter disables collectors listed [here](https://github.com/prometheus/node_exporter#disabled-by-default). |
-| `node_exporter_textfile_dir` | "/var/lib/node_exporter" | Directory used by the [Textfile Collector](https://github.com/prometheus/node_exporter#textfile-collector). To get permissions to write metrics in this directory, users must be in `node-exp` system group. __Note__: More information in TROUBLESHOOTING.md guide.
-| `node_exporter_tls_server_config` | {} | Configuration for TLS authentication. Keys and values are the same as in [node_exporter docs](https://github.com/prometheus/node_exporter/blob/master/https/README.md#sample-config). |
-| `node_exporter_http_server_config` | {} | Config for HTTP/2 support. Keys and values are the same as in [node_exporter docs](https://github.com/prometheus/node_exporter/blob/master/https/README.md#sample-config). |
-| `node_exporter_basic_auth_users` | {} | Dictionary of users and password for basic authentication. Passwords are automatically hashed with bcrypt. |
+All variables which can be overridden are stored in [defaults/main.yml](defaults/main.yml) file as well as in [meta/argument_specs.yml](meta/argument_specs.yml).
+Please refer to the [collection docs](https://prometheus-community.github.io/ansible/branch/main/node_exporter_role.html) for description and default values of the variables.
 
 ## Example
 

--- a/roles/prometheus/README.md
+++ b/roles/prometheus/README.md
@@ -13,37 +13,8 @@ Deploy [Prometheus](https://github.com/prometheus/prometheus) monitoring system 
 
 ## Role Variables
 
-All variables which can be overridden are stored in [defaults/main.yml](defaults/main.yml) file as well as in table below.
-
-| Name           | Default Value | Description                        |
-| -------------- | ------------- | -----------------------------------|
-| `prometheus_version` | 2.27.0 | Prometheus package version. Also accepts `latest` as parameter. Only prometheus 2.x is supported |
-| `prometheus_skip_install` | false | Prometheus installation tasks gets skipped when set to true. |
-| `prometheus_binary_local_dir` | "" | Allows to use local packages instead of ones distributed on github. As parameter it takes a directory where `prometheus` AND `promtool` binaries are stored on host on which ansible is ran. This overrides `prometheus_version` parameter |
-| `prometheus_config_dir` | /etc/prometheus | Path to directory with prometheus configuration |
-| `prometheus_binary_url` | `https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz` | URL of the prometheus binaries .tar.gz file |
-| `prometheus_checksums_url` | `https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/sha256sums.txt` | URL of the prometheus checksums file |
-| `prometheus_db_dir` | /var/lib/prometheus | Path to directory with prometheus database |
-| `prometheus_read_only_dirs`| [] | Additional paths that Prometheus is allowed to read (useful for SSL certs outside of the config directory) |
-| `prometheus_web_listen_address` | "0.0.0.0:9090" | Address on which prometheus will be listening |
-| `prometheus_web_config` | {} | A Prometheus [web config yaml](https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md) for configuring TLS and auth. |
-| `prometheus_web_external_url` | "" | External address on which prometheus is available. Useful when behind reverse proxy. Ex. `http://example.org/prometheus` |
-| `prometheus_storage_retention` | "30d" | Data retention period |
-| `prometheus_storage_retention_size` | "0" | Data retention period by size |
-| `prometheus_config_flags_extra` | {} | Additional configuration flags passed to prometheus binary at startup |
-| `prometheus_alertmanager_config` | [] | Configuration responsible for pointing where alertmanagers are. This should be specified as list in yaml format. It is compatible with official [<alertmanager_config>](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#alertmanager_config) |
-| `prometheus_alert_relabel_configs` | [] | Alert relabeling rules. This should be specified as list in yaml format. It is compatible with the official [<alert_relabel_configs>](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#alert_relabel_configs) |
-| `prometheus_global` | { scrape_interval: 60s, scrape_timeout: 15s, evaluation_interval: 15s } | Prometheus global config. Compatible with [official configuration](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#configuration-file) |
-| `prometheus_remote_write` | [] | Remote write. Compatible with [official configuration](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write) |
-| `prometheus_remote_read` | [] | Remote read. Compatible with [official configuration](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_read) |
-| `prometheus_external_labels` | environment: "{{ ansible_fqdn \| default(ansible_host) \| default(inventory_hostname) }}" | Provide map of additional labels which will be added to any time series or alerts when communicating with external systems |
-| `prometheus_targets` | {} | Targets which will be scraped. |
-| `prometheus_scrape_configs` | [defaults/main.yml#L75](https://github.com/prometheus-community/ansible/blob/685521ccb25e28a888a363d962822ee745ab6f6c/roles/prometheus/defaults/main.yml#L75) | Prometheus scrape jobs provided in same format as in [official docs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config) |
-| `prometheus_config_file` | "prometheus.yml.j2" | Variable used to provide custom prometheus configuration file in form of ansible template |
-| `prometheus_alert_rules` | [defaults/main.yml#L97](https://github.com/prometheus-community/ansible/blob/685521ccb25e28a888a363d962822ee745ab6f6c/roles/prometheus/defaults/main.yml#L97) | Full list of alerting rules which will be copied to `{{ prometheus_config_dir }}/rules/ansible_managed.rules`. Alerting rules can be also provided by other files located in `{{ prometheus_config_dir }}/rules/` which have `*.rules` extension |
-| `prometheus_alert_rules_files` | [defaults/main.yml#L89](https://github.com/prometheus-community/ansible/blob/685521ccb25e28a888a363d962822ee745ab6f6c/roles/prometheus/defaults/main.yml#L89) | List of folders where ansible will look for files containing alerting rules which will be copied to `{{ prometheus_config_dir }}/rules/`. Files must have `*.rules` extension |
-| `prometheus_static_targets_files` | [defaults/main.yml#L92](https://github.com/prometheus-community/ansible/blob/685521ccb25e28a888a363d962822ee745ab6f6c/roles/prometheus/defaults/main.yml#L92) | List of folders where ansible will look for files containing custom static target configuration files which will be copied to `{{ prometheus_config_dir }}/file_sd/`. |
-
+All variables which can be overridden are stored in [defaults/main.yml](defaults/main.yml) file as well as in [meta/argument_specs.yml](meta/argument_specs.yml).
+Please refer to the [collection docs](https://prometheus-community.github.io/ansible/branch/main/prometheus_role.html) for description and default values of the variables.
 
 ### Relation between `prometheus_scrape_configs` and `prometheus_targets`
 

--- a/roles/snmp_exporter/README.md
+++ b/roles/snmp_exporter/README.md
@@ -12,16 +12,8 @@ Deploy and manage prometheus [SNMP exporter](https://github.com/prometheus/snmp_
 
 ## Role Variables
 
-All variables which can be overridden are stored in [defaults/main.yml](defaults/main.yml) file as well as in table below.
-
-| Name           | Default Value | Description                        |
-| -------------- | ------------- | -----------------------------------|
-| `snmp_exporter_version` | 0.19.0 | SNMP exporter package version |
-| `snmp_exporter_skip_install` | false | SNMP exporter installation tasks gets skipped when set to true. |
-| `snmp_exporter_binary_url` | `https://github.com/prometheus/snmp_exporter/releases/download/v{{ snmp_exporter_version }}/snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz` | URL of the snmp exporter binaries .tar.gz file |
-| `snmp_exporter_checksums_url` | `https://github.com/prometheus/snmp_exporter/releases/download/v{{ snmp_exporter_version }}/sha256sums.txt` | URL of the snmp exporter checksums file |
-| `snmp_exporter_web_listen_address` | "0.0.0.0:9116" | Address on which SNMP exporter will be listening |
-| `snmp_exporter_config_file` | "" | If this is empty, role will download snmp.yml file from https://github.com/prometheus/snmp_exporter. Otherwise this should contain path to file with custom snmp exporter configuration |
+All variables which can be overridden are stored in [defaults/main.yml](defaults/main.yml) file as well as in [meta/argument_specs.yml](meta/argument_specs.yml).
+Please refer to the [collection docs](https://prometheus-community.github.io/ansible/branch/main/snmp_exporter_role.html) for description and default values of the variables.
 
 ## Example
 

--- a/roles/systemd_exporter/README.md
+++ b/roles/systemd_exporter/README.md
@@ -13,21 +13,8 @@ Deploy prometheus [systemd exporter](https://github.com/prometheus-community/sys
 
 ## Role Variables
 
-All variables which can be overridden are stored in [defaults/main.yml](defaults/main.yml) file as well as in table below.
-
-| Name           | Default Value | Description                        |
-| -------------- | ------------- | -----------------------------------|
-| `systemd_exporter_version` | 0.4.0 | SystemD exporter package version. Also accepts latest as parameter. |
-| `systemd_exporter_skip_install` | false | SystemD exporter installation tasks gets skipped when set to true. |
-| `systemd_exporter_binary_local_dir` | "" | Allows to use local packages instead of ones distributed on github. As parameter it takes a directory where `systemd_exporter` binary is stored on host on which ansible is ran. This overrides `systemd_exporter_version` parameter |
-| `systemd_exporter_binary_url` | `https://github.com/prometheus-community/systemd_exporter/releases/download/v{{ systemd_exporter_version }}/systemd_exporter-{{ systemd_exporter_version }}.linux-{{ go_arch }}.tar.gz` | URL of the systemd exporter binaries .tar.gz file |
-| `systemd_exporter_checksums_url` | `https://github.com/prometheus-community/systemd_exporter/releases/download/v{{ systemd_exporter_version }}/sha256sums.txt` | URL of the systemd exporter checksums file |
-| `systemd_exporter_web_listen_address` | "0.0.0.0:9558" | Address on which systemd exporter will listen |
-| `systemd_exporter_enable_restart_count` | false | Enables service restart count metrics. This feature only works with systemd 235 and above |
-| `systemd_exporter_enable_ip_accounting` | false | Enables service ip accounting metrics. This feature only works with systemd 235 and above |
-| `systemd_exporter_enable_file_descriptor_size` | false | Enables file descriptor size metrics. This feature will cause exporter to run as root as it needs access to /proc/X/fd |
-| `systemd_exporter_unit_allowlist` | "" | Include some systemd units. Expects a regex. More in https://github.com/prometheus-community/systemd_exporter#configuration |
-| `systemd_exporter_unit_denylist` | "" | Exclude some systemd units. Expects a regex. More in https://github.com/prometheus-community/systemd_exporter#configuration |
+All variables which can be overridden are stored in [defaults/main.yml](defaults/main.yml) file as well as in [meta/argument_specs.yml](meta/argument_specs.yml).
+Please refer to the [collection docs](https://prometheus-community.github.io/ansible/branch/main/systemd_exporter_role.html) for description and default values of the variables.
 
 ## Example
 


### PR DESCRIPTION
No need to maintain variable documentation in README when we got our online docs which are automatically generated.