### PR TITLE
fix: lookup('url', ..) causes known issue on MacOS controllers

### DIFF
--- a/roles/node_exporter/tasks/install.yml
+++ b/roles/node_exporter/tasks/install.yml
@@ -17,7 +17,7 @@
     home: /
   when: node_exporter_system_user != "root"
 
-- name: Discover latest version
+- name: Install from non-local archive
   when:
     - node_exporter_binary_local_dir | length == 0
     - not node_exporter_skip_install

--- a/roles/node_exporter/tasks/install.yml
+++ b/roles/node_exporter/tasks/install.yml
@@ -22,18 +22,12 @@
     - node_exporter_binary_local_dir | length == 0
     - not node_exporter_skip_install
   block:
-    - name: create temporary directory for download
-      become: false
-      ansible.builtin.tempfile:
-        state: directory
-      register: __node_exporter_tempdir
-      delegate_to: localhost
 
     - name: Download node_exporter binary to local folder
       become: false
       ansible.builtin.get_url:
         url: "{{ node_exporter_binary_url }}"
-        dest: "{{ __node_exporter_tempdir.path }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
+        dest: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
         checksum: "sha256:{{ __node_exporter_checksum }}"
         mode: '0644'
       register: _download_binary
@@ -46,29 +40,21 @@
     - name: Unpack node_exporter binary
       become: false
       ansible.builtin.unarchive:
-        src: "{{ __node_exporter_tempdir.path }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
-        dest: "{{ __node_exporter_tempdir.path }}"
-        creates: "{{ __node_exporter_tempdir.path }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}/node_exporter"
+        src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
+        dest: "/tmp"
+        creates: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}/node_exporter"
       delegate_to: localhost
       check_mode: false
 
     - name: Propagate node_exporter binaries
       ansible.builtin.copy:
-        src: "{{ __node_exporter_tempdir.path }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}/node_exporter"
+        src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}/node_exporter"
         dest: "{{ node_exporter_binary_install_dir }}/node_exporter"
         mode: 0755
         owner: root
         group: root
       notify: restart node_exporter
       when: not ansible_check_mode
-
-  always:
-    - name: delete locally downloaded data
-      become: false
-      ansible.builtin.file:
-        path: "{{ __node_exporter_tempdir.path }}"
-        state: absent
-      delegate_to: localhost
 
 - name: Propagate locally distributed node_exporter binary
   ansible.builtin.copy:

--- a/roles/node_exporter/tasks/install.yml
+++ b/roles/node_exporter/tasks/install.yml
@@ -22,12 +22,18 @@
     - node_exporter_binary_local_dir | length == 0
     - not node_exporter_skip_install
   block:
+    - name: create temporary directory for download
+      become: false
+      ansible.builtin.tempfile:
+        state: directory
+      register: __node_exporter_tempdir
+      delegate_to: localhost
 
     - name: Download node_exporter binary to local folder
       become: false
       ansible.builtin.get_url:
         url: "{{ node_exporter_binary_url }}"
-        dest: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
+        dest: "{{ __node_exporter_tempdir.path }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
         checksum: "sha256:{{ __node_exporter_checksum }}"
         mode: '0644'
       register: _download_binary
@@ -40,21 +46,29 @@
     - name: Unpack node_exporter binary
       become: false
       ansible.builtin.unarchive:
-        src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
-        dest: "/tmp"
-        creates: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}/node_exporter"
+        src: "{{ __node_exporter_tempdir.path }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
+        dest: "{{ __node_exporter_tempdir.path }}"
+        creates: "{{ __node_exporter_tempdir.path }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}/node_exporter"
       delegate_to: localhost
       check_mode: false
 
     - name: Propagate node_exporter binaries
       ansible.builtin.copy:
-        src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}/node_exporter"
+        src: "{{ __node_exporter_tempdir.path }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}/node_exporter"
         dest: "{{ node_exporter_binary_install_dir }}/node_exporter"
         mode: 0755
         owner: root
         group: root
       notify: restart node_exporter
       when: not ansible_check_mode
+
+  always:
+    - name: delete locally downloaded data
+      become: false
+      ansible.builtin.file:
+        path: "{{ __node_exporter_tempdir.path }}"
+        state: absent
+      delegate_to: localhost
 
 - name: Propagate locally distributed node_exporter binary
   ansible.builtin.copy:

--- a/roles/node_exporter/tasks/preflight.yml
+++ b/roles/node_exporter/tasks/preflight.yml
@@ -79,11 +79,14 @@
     - not node_exporter_skip_install
   block:
     - name: get the version
+      become: false
       ansible.builtin.uri:
         url: https://api.github.com/repos/prometheus/node_exporter/releases/latest
       run_once: true
       retries: 10
       register: __node_exporter_latest_version_info
+      delegate_to: localhost
+
 
     - name: set the version
       ansible.builtin.set_fact:
@@ -96,12 +99,14 @@
     - not node_exporter_skip_install
   block:
     - name: Get checksum list from github
+      become: false
       ansible.builtin.uri:
         url: "{{ node_exporter_checksums_url }}"
         return_content: true
       run_once: true
       retries: 10
       register: __node_exporter_checksums
+      delegate_to: localhost
       failed_when: __node_exporter_checksums.content is not search('linux-' + go_arch + '.tar.gz')
 
     - name: "Get checksum for {{ go_arch }}"

--- a/roles/node_exporter/tasks/preflight.yml
+++ b/roles/node_exporter/tasks/preflight.yml
@@ -73,16 +73,22 @@
     - node_exporter_install
 
 - name: Discover latest version
-  ansible.builtin.set_fact:
-    node_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/prometheus/node_exporter/releases/latest', split_lines=False) |
-                            from_json).get('tag_name') | replace('v', '') }}"
-  run_once: true
-  until: node_exporter_version is version('0.0.0', '>=')
-  retries: 10
   when:
     - node_exporter_version == "latest"
     - node_exporter_binary_local_dir | length == 0
     - not node_exporter_skip_install
+  block:
+    - name: get the version
+      ansible.builtin.uri:
+        url: https://api.github.com/repos/prometheus/node_exporter/releases/latest
+      run_once: true
+      retries: 10
+      register: __node_exporter_latest_version_info
+
+    - name: set the version
+      ansible.builtin.set_fact:
+        node_exporter_version: "{{ __node_exporter_latest_version_info.json.tag_name | replace('v', '') }}"
+      failed_when: node_exporter_version is not version('0.0.0', '>=')
 
 - name: Get node_exporter binary checksum
   when:
@@ -90,15 +96,17 @@
     - not node_exporter_skip_install
   block:
     - name: Get checksum list from github
-      ansible.builtin.set_fact:
-        __node_exporter_checksums: "{{ lookup('url', node_exporter_checksums_url, wantlist=True) | list }}"
+      ansible.builtin.uri:
+        url: "{{ node_exporter_checksums_url }}"
+        return_content: true
       run_once: true
-      until: __node_exporter_checksums is search('linux-' + go_arch + '.tar.gz')
       retries: 10
+      register: __node_exporter_checksums
+      failed_when: __node_exporter_checksums.content is not search('linux-' + go_arch + '.tar.gz')
 
     - name: "Get checksum for {{ go_arch }}"
       ansible.builtin.set_fact:
         __node_exporter_checksum: "{{ item.split(' ')[0] }}"
-      with_items: "{{ __node_exporter_checksums }}"
+      with_items: "{{ __node_exporter_checksums.content.splitlines() }}"
       when:
         - "('linux-' + go_arch + '.tar.gz') in item"


### PR DESCRIPTION
This PR addresses a [known issue](https://github.com/ansible/ansible/issues/76322) running `lookup('url', ..)` on MacOS.

The writeup in the issue indicates that there are 2 possible solutions:
1. uninstall requests and urllib3
2. use the uri module instead of the lookup

This ticket pursues the latter option, as the former is unrealistic for many users.

Additionally, this work includes downloading the node_exporter archive into a temporary directory, which is cleaned up after copying the extracted binary to the target.