### PR TITLE
fix: pass token to github api for higher ratelimit

### DIFF
--- a/.github/workflows/ansible-test-integration.yml
+++ b/.github/workflows/ansible-test-integration.yml
@@ -37,3 +37,5 @@ jobs:
           testing-type: integration
           target: ${{ matrix.targets.test }}
           # coverage: never  # https://github.com/ansible-community/ansible-test-gh-action/pull/50
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/roles/alertmanager/tasks/preflight.yml
+++ b/roles/alertmanager/tasks/preflight.yml
@@ -21,8 +21,8 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    alertmanager_version: "{{ (lookup('url', 'https://api.github.com/repos/prometheus/alertmanager/releases/latest', split_lines=False) |
-                            from_json).get('tag_name') | replace('v', '') }}"
+    alertmanager_version: "{{ (lookup('url', 'https://api.github.com/repos/prometheus/alertmanager/releases/latest', headers=_github_api_headers,
+                           split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: alertmanager_version is version('0.0.0', '>=')
   retries: 10
@@ -38,7 +38,7 @@
   block:
     - name: "Get checksum list"
       ansible.builtin.set_fact:
-        __alertmanager_checksums: "{{ lookup('url', alertmanager_checksums_url, wantlist=True) | list }}"
+        __alertmanager_checksums: "{{ lookup('url', alertmanager_checksums_url, headers=_github_api_headers, wantlist=True) | list }}"
       run_once: true
       until: __alertmanager_checksums is search('linux-' + go_arch + '.tar.gz')
       retries: 10

--- a/roles/alertmanager/vars/main.yml
+++ b/roles/alertmanager/vars/main.yml
@@ -12,3 +12,4 @@ _alertmanager_binary_install_dir: '/usr/local/bin'
 # The expected location of the amtool configuration file
 _alertmanager_amtool_config_dir: '/etc/amtool'
 _alertmanager_repo: "prometheus/alertmanager"
+_github_api_headers: "{{ {'GITHUB_TOKEN': lookup('ansible.builtin.env', 'GITHUB_TOKEN')} if (lookup('ansible.builtin.env', 'GITHUB_TOKEN')) else {} }}"

--- a/roles/mysqld_exporter/tasks/preflight.yml
+++ b/roles/mysqld_exporter/tasks/preflight.yml
@@ -74,8 +74,8 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    mysqld_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/prometheus/mysqld_exporter/releases/latest', split_lines=False) |
-                            from_json).get('tag_name') | replace('v', '') }}"
+    mysqld_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/prometheus/mysqld_exporter/releases/latest', headers=_github_api_headers,
+                              split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: mysqld_exporter_version is version('0.0.0', '>=')
   retries: 10
@@ -91,7 +91,7 @@
   block:
     - name: Get checksum list from github
       ansible.builtin.set_fact:
-        __mysqld_exporter_checksums: "{{ lookup('url', mysqld_exporter_checksums_url, wantlist=True) | list }}"
+        __mysqld_exporter_checksums: "{{ lookup('url', mysqld_exporter_checksums_url, headers=_github_api_headers, wantlist=True) | list }}"
       run_once: true
       until: __mysqld_exporter_checksums is search('linux-' + go_arch + '.tar.gz')
       retries: 10

--- a/roles/mysqld_exporter/vars/main.yml
+++ b/roles/mysqld_exporter/vars/main.yml
@@ -9,3 +9,4 @@ go_arch_map:
 go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
 
 _mysqld_exporter_repo: "prometheus/mysqld_exporter"
+_github_api_headers: "{{ {'GITHUB_TOKEN': lookup('ansible.builtin.env', 'GITHUB_TOKEN')} if (lookup('ansible.builtin.env', 'GITHUB_TOKEN')) else {} }}"

--- a/roles/node_exporter/tasks/preflight.yml
+++ b/roles/node_exporter/tasks/preflight.yml
@@ -74,8 +74,8 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    node_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/prometheus/node_exporter/releases/latest', split_lines=False) |
-                            from_json).get('tag_name') | replace('v', '') }}"
+    node_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/prometheus/node_exporter/releases/latest', headers=_github_api_headers,
+                            split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: node_exporter_version is version('0.0.0', '>=')
   retries: 10
@@ -91,7 +91,7 @@
   block:
     - name: Get checksum list from github
       ansible.builtin.set_fact:
-        __node_exporter_checksums: "{{ lookup('url', node_exporter_checksums_url, wantlist=True) | list }}"
+        __node_exporter_checksums: "{{ lookup('url', node_exporter_checksums_url, headers=_github_api_headers, wantlist=True) | list }}"
       run_once: true
       until: __node_exporter_checksums is search('linux-' + go_arch + '.tar.gz')
       retries: 10

--- a/roles/node_exporter/vars/main.yml
+++ b/roles/node_exporter/vars/main.yml
@@ -8,3 +8,4 @@ go_arch_map:
 
 go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
 _node_exporter_repo: "prometheus/node_exporter"
+_github_api_headers: "{{ {'GITHUB_TOKEN': lookup('ansible.builtin.env', 'GITHUB_TOKEN')} if (lookup('ansible.builtin.env', 'GITHUB_TOKEN')) else {} }}"

--- a/roles/prometheus/tasks/preflight.yml
+++ b/roles/prometheus/tasks/preflight.yml
@@ -74,8 +74,8 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    prometheus_version: "{{ (lookup('url', 'https://api.github.com/repos/prometheus/prometheus/releases/latest', split_lines=False) |
-                         from_json).get('tag_name') | replace('v', '') }}"
+    prometheus_version: "{{ (lookup('url', 'https://api.github.com/repos/prometheus/prometheus/releases/latest', headers=_github_api_headers,
+                         split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: prometheus_version is version('0.0.0', '>=')
   retries: 10
@@ -91,7 +91,7 @@
   block:
     - name: "Get checksum list"
       ansible.builtin.set_fact:
-        __prometheus_checksums: "{{ lookup('url', prometheus_checksums_url, wantlist=True) | list }}"
+        __prometheus_checksums: "{{ lookup('url', prometheus_checksums_url, headers=_github_api_headers, wantlist=True) | list }}"
       run_once: true
       until: __prometheus_checksums is search('linux-' + go_arch + '.tar.gz')
       retries: 10

--- a/roles/prometheus/vars/main.yml
+++ b/roles/prometheus/vars/main.yml
@@ -13,3 +13,4 @@ _prometheus_selinux_packages: "{{ ['libselinux-python', 'policycoreutils-python'
                                if ansible_python_version is version('3', '<') else
                                ['python3-libselinux', 'python3-policycoreutils'] }}"
 _prometheus_repo: "prometheus/prometheus"
+_github_api_headers: "{{ {'GITHUB_TOKEN': lookup('ansible.builtin.env', 'GITHUB_TOKEN')} if (lookup('ansible.builtin.env', 'GITHUB_TOKEN')) else {} }}"

--- a/roles/snmp_exporter/tasks/preflight.yml
+++ b/roles/snmp_exporter/tasks/preflight.yml
@@ -3,7 +3,7 @@
   ansible.builtin.set_fact:
     snmp_exporter_checksum: "{{ item.split(' ')[0] }}"
   with_items:
-    - "{{ lookup('url', snmp_exporter_checksums_url, wantlist=True) | list }}"
+    - "{{ lookup('url', snmp_exporter_checksums_url, headers=_github_api_headers, wantlist=True) | list }}"
   when:
     - "('linux-' + (go_arch_map[ansible_architecture] | default(ansible_architecture)) + '.tar.gz') in item"
     - not snmp_exporter_skip_install

--- a/roles/snmp_exporter/vars/main.yml
+++ b/roles/snmp_exporter/vars/main.yml
@@ -6,3 +6,4 @@ go_arch_map:
   armv7l: 'armv7'
   armv6l: 'armv6'
 _snmp_exporter_repo: "prometheus/snmp_exporter"
+_github_api_headers: "{{ {'GITHUB_TOKEN': lookup('ansible.builtin.env', 'GITHUB_TOKEN')} if (lookup('ansible.builtin.env', 'GITHUB_TOKEN')) else {} }}"

--- a/roles/systemd_exporter/tasks/preflight.yml
+++ b/roles/systemd_exporter/tasks/preflight.yml
@@ -56,8 +56,8 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    systemd_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/prometheus-community/systemd_exporter/releases/latest', split_lines=False) |
-                            from_json).get('tag_name') | replace('v', '') }}"
+    systemd_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/prometheus-community/systemd_exporter/releases/latest',
+                               headers=_github_api_headers, split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: systemd_exporter_version is version('0.0.0', '>=')
   retries: 10
@@ -73,7 +73,7 @@
   block:
     - name: Get checksum list from github
       ansible.builtin.set_fact:
-        _systemd_exporter_checksums: "{{ lookup('url', systemd_exporter_checksums_url, wantlist=True) | list }}"
+        _systemd_exporter_checksums: "{{ lookup('url', systemd_exporter_checksums_url, headers=_github_api_headers, wantlist=True) | list }}"
       run_once: true
       until: _systemd_exporter_checksums is search('linux-' + go_arch + '.tar.gz')
       retries: 10

--- a/roles/systemd_exporter/vars/main.yml
+++ b/roles/systemd_exporter/vars/main.yml
@@ -8,3 +8,4 @@ go_arch_map:
 
 go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
 _systemd_exporter_repo: "prometheus-community/systemd_exporter"
+_github_api_headers: "{{ {'GITHUB_TOKEN': lookup('ansible.builtin.env', 'GITHUB_TOKEN')} if (lookup('ansible.builtin.env', 'GITHUB_TOKEN')) else {} }}"


### PR DESCRIPTION
Apparently the github api has a rate limit of 60 requests per hour for unauthenticated requests, but if we authenticate the requests with `GITHUB_TOKEN` from the CI we get 1000 requests per hour.
This PR passes the token to ansible, so we should see less failures in CI runs.