### PR TITLE
fix: node_exporter - Add test for ProtectHome

### DIFF
--- a/roles/node_exporter/molecule/alternative/prepare.yml
+++ b/roles/node_exporter/molecule/alternative/prepare.yml
@@ -76,3 +76,18 @@
           dest: "{{ node_exporter_tls_server_config.cert_file }}"
         - src: "/tmp/tls.key"
           dest: "{{ node_exporter_tls_server_config.key_file }}"
+
+    - name: Create test mount directory
+      ansible.builtin.file:
+        path: /home/test
+        state: directory
+        owner: root
+        group: root
+        mode: 0755
+
+    - name: Mount test filesystem
+      ansible.posix.mount:
+        path: /home/test
+        src: tmpfs
+        fstype: tmpfs
+        state: mounted


### PR DESCRIPTION
Add a tmpfs mount to the node_exporter testing to make sure ProtectHome is changed.