### PR TITLE
Fix broken link on systemd exporter

### DIFF
--- a/branch/main/systemd_exporter_role.html
+++ b/branch/main/systemd_exporter_role.html
@@ -142,7 +142,7 @@
 <section id="synopsis">
 <h3><a class="toc-backref" href="#id2" role="doc-backlink">Synopsis</a><a class="headerlink" href="#synopsis" title="Permalink to this heading"></a></h3>
 <ul class="simple">
-<li><p>Deploy prometheus <a class="reference external" href="%2Chttps://github.com/prometheus-community/systemd_exporter">systemd exporter</a> using ansible.</p></li>
+<li><p>Deploy prometheus <a class="reference external" href="https://github.com/prometheus-community/systemd_exporter">systemd exporter</a> using ansible.</p></li>
 </ul>
 </section>
 <section id="parameters">


### PR DESCRIPTION
The link here is currently routing to a 404. This change should fix the link so that it routes properly.

https://prometheus-community.github.io/ansible/branch/main/systemd_exporter_role.html#synopsis