### PR TITLE
patch: New prometheus/prometheus upstream release!

### DIFF
--- a/roles/prometheus/defaults/main.yml
+++ b/roles/prometheus/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-prometheus_version: 2.27.0
+prometheus_version: 2.44.0
 prometheus_binary_local_dir: ''
 prometheus_binary_url: "https://github.com/{{ _prometheus_repo }}/releases/download/v{{ prometheus_version }}/\
                         prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"

--- a/roles/prometheus/meta/argument_specs.yml
+++ b/roles/prometheus/meta/argument_specs.yml
@@ -12,7 +12,7 @@ argument_specs:
         description:
           - "Prometheus package version. Also accepts C(latest) as parameter."
           - "Only prometheus 2.x is supported"
-        default: "2.27.0"
+        default: "2.44.0"
       prometheus_skip_install:
         description: "Prometheus installation tasks gets skipped when set to true."
         type: bool


### PR DESCRIPTION
The upstream [prometheus/prometheus](https://github.com/prometheus/prometheus/releases) released new software version - **2.44.0**!

This automated PR updates code to bring new version into repository.