### PR TITLE
fix: don't require role name on internal vars

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -2,3 +2,5 @@
 profile: production
 warn_list:
   - galaxy[version-incorrect]  # until collection gets bumped to 1.x.x
+skip_list:
+  - var-naming[no-role-prefix]  # https://github.com/ansible/ansible-lint/pull/3422#issuecomment-1549584988


### PR DESCRIPTION
This disables the linting rule `no-role-prefix` which got introduced in [ansible-lint v6.16.1](https://github.com/ansible/ansible-lint/releases/tag/v6.16.1). 

We prefer to use leading underscores to distinguish internal variables [as in python](https://peps.python.org/pep-0008/#descriptive-naming-styles) rather than prefixing them with the role name.
https://github.com/ansible/ansible-lint/pull/3422#issuecomment-1549584988