### PR TITLE
skip_changelog: More fixes to version bumper

### DIFF
--- a/.github/scripts/version_updater.sh
+++ b/.github/scripts/version_updater.sh
@@ -81,6 +81,13 @@ yq eval -i ".argument_specs.main.options.${role}_version.default = \"${version}\
 
 update_branch="autoupdate/${role}/${version}"
 
+remote_branch="$(github_api "repos/${GIT_REPO}/branches/${update_branch}" | jq -r .name)"
+
+if [[ -n "${remote_branch}" ]] ; then
+  echo_yellow "Branch is already on remote."
+  exit 0
+fi
+
 # Push new version
 git config user.email "${GIT_MAIL}"
 git config user.name "${GIT_USER}"
@@ -92,8 +99,8 @@ git add \
 git commit -m 'patch: :tada: automated upstream release update'
 echo_green "Pushing to ${update_branch} branch in ${role}"
 if ! git push "https://${GITHUB_TOKEN}:@github.com/${GIT_REPO}" --set-upstream "${update_branch}"; then
-    echo_yellow "Branch is already on remote."
-    exit 0
+    echo_yellow "Branch push failed."
+    exit 1
 fi
 
 if ! post_pull_request \

--- a/.github/workflows/version_bumper.yml
+++ b/.github/workflows/version_bumper.yml
@@ -27,6 +27,7 @@ jobs:
     needs: discover-role-repos
     permissions:
       contents: write
+      pull-request: write
     container:
       image: quay.io/prometheus/golang-builder:base
     env:


### PR DESCRIPTION
* Check for remote branch before trying to build a changeset.
* Fail exit if push fails.
* Add pull-request permission to workflow.