### PR TITLE
fix: Skip config validation when not installing

### DIFF
--- a/roles/alertmanager/tasks/configure.yml
+++ b/roles/alertmanager/tasks/configure.yml
@@ -16,7 +16,9 @@
     owner: alertmanager
     group: alertmanager
     mode: 0644
-    validate: "{{ _alertmanager_binary_install_dir }}/amtool check-config %s"
+    validate: >-
+      {{ omit if alertmanager_skip_install else
+         _alertmanager_binary_install_dir + '/amtool check-config %s' }}
   no_log: "{{ 'false' if lookup('env', 'CI') else 'true' }}"
   notify:
     - restart alertmanager


### PR DESCRIPTION
Otherwise validation fails because amtool binary is missing.