### PR TITLE
fix: alertmanager deprecated PIDFile= path warning

### DIFF
--- a/roles/alertmanager/templates/alertmanager.service.j2
+++ b/roles/alertmanager/templates/alertmanager.service.j2
@@ -17,7 +17,11 @@ StartLimitIntervalSec=0
 
 [Service]
 Type=simple
+{% if (ansible_facts.packages.systemd | first).version is version('239', '>=') %}
+PIDFile=/run/alertmanager.pid
+{% else %}
 PIDFile=/var/run/alertmanager.pid
+{% endif %}
 User=alertmanager
 Group=alertmanager
 ExecReload=/bin/kill -HUP $MAINPID


### PR DESCRIPTION
Starting from systemd 239 ([commit link](https://github.com/systemd/systemd/commit/a2d1fb882c4308bc10362d971f333c5031d60069)), it started showing warning about using deprecated path to pidfile in `/var/run` instead of `/run`.

This warning can be seen by launching command `systemctl status alertmanager` or sometring like `journalctl -xeu alertmanager`:

```/etc/systemd/system/alertmanager.service:12: PIDFile= references a path below legacy directory /var/run/, updating /var/run/alertmanager.pid → /run/alertmanager.pid; please update the unit file accordingly.```