### PR TITLE
feat: add option to disable all default node_exporter collectors

### DIFF
--- a/roles/node_exporter/defaults/main.yml
+++ b/roles/node_exporter/defaults/main.yml
@@ -27,6 +27,8 @@ node_exporter_enabled_collectors:
 
 node_exporter_disabled_collectors: []
 
+node_exporter_disable_default_collectors: false
+
 node_exporter_binary_install_dir: "/usr/local/bin"
 node_exporter_system_group: "node-exp"
 node_exporter_system_user: "{{ node_exporter_system_group }}"

--- a/roles/node_exporter/meta/argument_specs.yml
+++ b/roles/node_exporter/meta/argument_specs.yml
@@ -47,6 +47,12 @@ argument_specs:
           - "By default node_exporter disables collectors listed L(here,https://github.com/prometheus/node_exporter#disabled-by-default)."
         type: "list"
         elements: "str"
+      node_exporter_disable_default_collectors:
+        description:
+          - "Bool to control whether to disable the default enabled collectors."
+          - "Use in combination with node_exporter_enabled_collectors to set an explicit list of collectors to use."
+        type: bool
+        default: false
       node_exporter_textfile_dir:
         description:
           - "Directory used by the L(Textfile Collector,https://github.com/prometheus/node_exporter#textfile-collector)."

--- a/roles/node_exporter/templates/node_exporter.service.j2
+++ b/roles/node_exporter/templates/node_exporter.service.j2
@@ -9,6 +9,9 @@ Type=simple
 User={{ node_exporter_system_user }}
 Group={{ node_exporter_system_group }}
 ExecStart={{ node_exporter_binary_install_dir }}/node_exporter \
+{% if node_exporter_disable_default_collectors %}
+    '--collector.disable-defaults' \
+{% endif -%}
 {% for collector in node_exporter_enabled_collectors -%}
 {%   if not collector is mapping %}
     '--collector.{{ collector }}' \


### PR DESCRIPTION
Hi,
I'm new to the project, kinda new to ansible and not very used to github. Let me know if something looks wrong.
This PR will add the ability disable all default collectors, allowing you to set an explicit list of enabled collectors when used together with `node_exporter_enabled_collectors`. The behavior is documented over at [node_exporter repo](https://github.com/prometheus/node_exporter#collectors).

I didn't update any tests as updating `alternative` would impact the behavior of  the var `node_exporter_disabled_collectors`.