### PR TITLE
fix(node_exporter): correct indent in systemd template

### DIFF
--- a/roles/node_exporter/templates/node_exporter.service.j2
+++ b/roles/node_exporter/templates/node_exporter.service.j2
@@ -23,13 +23,13 @@ ExecStart={{ node_exporter_binary_install_dir }}/node_exporter \
 {% for collector in node_exporter_disabled_collectors %}
     '--no-collector.{{ collector }}' \
 {% endfor %}
-{% if node_exporter_tls_server_config | length > 0 or node_exporter_http_server_config | length > 0 or node_exporter_basic_auth_users | length > 0 %}
+{% if node_exporter_tls_server_config | length > 0 or node_exporter_http_server_config | length > 0 or node_exporter_basic_auth_users | length > 0 -%}
     {% if node_exporter_version is version('1.5.0', '>=') %}
     '--web.config.file=/etc/node_exporter/config.yaml' \
     {% else %}
     '--web.config=/etc/node_exporter/config.yaml' \
     {% endif %}
-{% endif %}
+{% endif -%}
     '--web.listen-address={{ node_exporter_web_listen_address }}' \
     '--web.telemetry-path={{ node_exporter_web_telemetry_path }}'
 

--- a/roles/node_exporter/templates/node_exporter.service.j2
+++ b/roles/node_exporter/templates/node_exporter.service.j2
@@ -13,7 +13,7 @@ ExecStart={{ node_exporter_binary_install_dir }}/node_exporter \
 {%   if not collector is mapping %}
     '--collector.{{ collector }}' \
 {%   else -%}
-{%     set name, options = (collector.items()|list)[0] -%}
+{%     set name, options = (collector.items()|list)[0] %}
     '--collector.{{ name }}' \
 {%     for k,v in options|dictsort %}
     '--collector.{{ name }}.{{ k }}={{ v }}' \


### PR DESCRIPTION
Before:
![image](https://github.com/prometheus-community/ansible/assets/10629864/f927070d-57c1-4e4b-ab2b-0c09b013f2f2)

After:
![image](https://github.com/prometheus-community/ansible/assets/10629864/55696ae6-e956-4888-be4c-b0395342f797)
