### PR TITLE
skip_changelog: Prefix role label triggers.

### DIFF
--- a/.github/workflows/ansible-ci.yml
+++ b/.github/workflows/ansible-ci.yml
@@ -69,7 +69,7 @@ jobs:
         env:
           LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: |
-          roles=$(echo $LABELS | jq -r '.[]')
+          roles=$(echo $LABELS | jq -r '.[]' | grep '^roles/' | sed 's|^roles/||')
           echo tests="[`for role in $roles; do
             for test in $(find tests/integration/targets -maxdepth 1 -mindepth 1 -type d -iname "molecule-${role}-*" -printf "%f\n"); do
               echo '{"test":\"'"${test}"'\","name":\"'"${test#*-}\"'"}';

--- a/.github/workflows/conventional-label.yml
+++ b/.github/workflows/conventional-label.yml
@@ -69,7 +69,7 @@ jobs:
           steps.changed-roles.outputs.all_changed_and_modified_files
         with:
           script: |
-            const labels = '${{ steps.changed-roles.outputs.all_changed_and_modified_files }}'.split(' ');
+            const labels = '${{ steps.changed-roles.outputs.all_changed_and_modified_files }}'.split(' ').map(i => 'roles/' + i);
             github.rest.issues.addLabels({
               issue_number: context.issue.number,
               owner: context.repo.owner,


### PR DESCRIPTION
Add the prefix `roles/` to the per-role label names in order to namespace them from other labels.