### PR TITLE
feature: blackbox exporter user/group configurable

### DIFF
--- a/roles/blackbox_exporter/defaults/main.yml
+++ b/roles/blackbox_exporter/defaults/main.yml
@@ -7,6 +7,9 @@ blackbox_exporter_skip_install: false
 
 blackbox_exporter_web_listen_address: "0.0.0.0:9115"
 
+blackbox_exporter_user: blackbox-exp
+blackbox_exporter_group: "{{ blackbox_exporter_user }}"
+
 blackbox_exporter_cli_flags: {}
 # blackbox_exporter_cli_flags:
 #   log.level: "warn"

--- a/roles/blackbox_exporter/tasks/configure.yml
+++ b/roles/blackbox_exporter/tasks/configure.yml
@@ -13,8 +13,8 @@
   ansible.builtin.template:
     src: blackbox_exporter.yml.j2
     dest: /etc/blackbox_exporter.yml
-    owner: blackbox-exp
-    group: blackbox-exp
+    owner: root
+    group: "{{ blackbox_exporter_group }}"
     mode: 0644
   notify:
     - reload blackbox exporter

--- a/roles/blackbox_exporter/tasks/install.yml
+++ b/roles/blackbox_exporter/tasks/install.yml
@@ -1,17 +1,19 @@
 ---
 - name: Create blackbox_exporter system group
   ansible.builtin.group:
-    name: blackbox-exp
+    name: "{{ blackbox_exporter_group }}"
     system: true
     state: present
+  when: blackbox_exporter_group != 'root'
 
 - name: Create blackbox_exporter system user
   ansible.builtin.user:
-    name: blackbox-exp
+    name: "{{ blackbox_exporter_user }}"
     system: true
     shell: "/usr/sbin/nologin"
-    group: blackbox-exp
+    group: "{{ blackbox_exporter_group }}"
     createhome: false
+  when: blackbox_exporter_user != 'root'
 
 - name: Download blackbox exporter binary to local folder
   become: false
@@ -35,8 +37,8 @@
           blackbox_exporter"
     dest: "/usr/local/bin/blackbox_exporter"
     mode: 0750
-    owner: blackbox-exp
-    group: blackbox-exp
+    owner: root
+    group: "{{ blackbox_exporter_group }}"
   when: not blackbox_exporter_skip_install
   notify:
     - restart blackbox exporter

--- a/roles/blackbox_exporter/templates/blackbox_exporter.service.j2
+++ b/roles/blackbox_exporter/templates/blackbox_exporter.service.j2
@@ -7,8 +7,8 @@ StartLimitIntervalSec=0
 
 [Service]
 Type=simple
-User=blackbox-exp
-Group=blackbox-exp
+User={{ blackbox_exporter_user }}
+Group={{ blackbox_exporter_group }}
 PermissionsStartOnly=true
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/usr/local/bin/blackbox_exporter \


### PR DESCRIPTION
Also, binary and configuration owner is changed to root. User blackbox-exp should be prevented from modifying or deleting either the configuration or itself, according to the principle of least privilege.