### PR TITLE
Impr: Skip more tasks when skipping installation

### DIFF
--- a/roles/blackbox_exporter/tasks/install.yml
+++ b/roles/blackbox_exporter/tasks/install.yml
@@ -49,14 +49,18 @@
   until: _download_packages is succeeded
   retries: 5
   delay: 2
-  when: ansible_os_family | lower == "debian"
+  when:
+    - ansible_os_family | lower == "debian"
+    - not blackbox_exporter_skip_install | bool
 
 - name: Ensure blackbox exporter binary has cap_net_raw capability
   community.general.capabilities:
     path: '/usr/local/bin/blackbox_exporter'
     capability: cap_net_raw+ep
     state: present
-  when: not ansible_check_mode
+  when:
+    - not ansible_check_mode
+    - not blackbox_exporter_skip_install | bool
   changed_when: "'molecule-idempotence-notest' not in ansible_skip_tags"
 
 - name: Check Debug Message

--- a/roles/blackbox_exporter/tasks/preflight.yml
+++ b/roles/blackbox_exporter/tasks/preflight.yml
@@ -9,7 +9,9 @@
   ansible.builtin.package:
     name: "{{ _pkg_fact_req }}"
     state: present
-  when: (_pkg_fact_req)
+  when:
+    - (_pkg_fact_req)
+    - not blackbox_exporter_skip_install | bool
   vars:
     _pkg_fact_req: "{% if (ansible_pkg_mgr == 'apt') %}\
                     {{ ('python-apt' if ansible_python_version is version('3', '<') else 'python3-apt') }}


### PR DESCRIPTION
When not installing, /usr/local/bin/blackbox_exporter is not guaranteed to be present. Which means that applying cap_net_raw capability to it may fail and should be skipped too. This means that installing the libcap2-bin package may be unnecessary, if not contradicting the principle of the 'skip_install' setting. And the same goes for the installation of the python3-apt package in the preflight script.

All of the above are irrelevant when using this role to setup the configuration of a container which comes with everything pre-installed.