### PR TITLE
Fix: Install node_exporter on the target machine instead of the provisioning

### DIFF
--- a/roles/node_exporter/tasks/install.yml
+++ b/roles/node_exporter/tasks/install.yml
@@ -34,7 +34,7 @@
       until: _download_binary is succeeded
       retries: 5
       delay: 2
-      delegate_to: localhost
+      delegate_to: "{{ groups['targets'][0] }}"
       check_mode: false
 
     - name: Unpack node_exporter binary
@@ -43,7 +43,7 @@
         src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
         dest: "/tmp"
         creates: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}/node_exporter"
-      delegate_to: localhost
+      delegate_to: "{{ groups['targets'][0] }}"
       check_mode: false
 
     - name: Propagate node_exporter binaries


### PR DESCRIPTION
When trying to install node_exporter on the target machines, at a certain point the binaries would start to be installed on the machine where ansible is running which is not the point when doing automation tasks. This correction will avoid the installation of the exporter on the provisioning machine and also solve this error:
TASK [prometheus.prometheus.node_exporter : Download node_exporter binary to local folder] ************************
fatal: [...*]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: ubuntu@localhost: Permission denied (publickey).", "unreachable": true}

Now, the binaries will be downloaded to ubuntu@targetmachine instead of ubuntu@localhost