### PR TITLE
fix(node_exporter): Fix ProtectHome for textfiles

### DIFF
--- a/roles/node_exporter/molecule/latest/molecule.yml
+++ b/roles/node_exporter/molecule/latest/molecule.yml
@@ -4,3 +4,4 @@ provisioner:
     group_vars:
       all:
         node_exporter_version: latest
+        node_exporter_textfile_dir: /home/node_exporter

--- a/roles/node_exporter/molecule/latest/tests/test_latest.py
+++ b/roles/node_exporter/molecule/latest/tests/test_latest.py
@@ -19,6 +19,16 @@ def test_files(host, files):
     assert f.is_file
 
 
+def test_directories(host):
+    dirs = [
+        "/home/node_exporter"
+    ]
+    for dir in dirs:
+        d = host.file(dir)
+        assert d.is_directory
+        assert d.exists
+
+
 def test_service(host):
     s = host.service("node_exporter")
     try:
@@ -35,7 +45,7 @@ def test_service(host):
 def test_protecthome_property(host):
     s = host.service("node_exporter")
     p = s.systemd_properties
-    assert p.get("ProtectHome") == "yes"
+    assert p.get("ProtectHome") == "read-only"
 
 
 def test_socket(host):

--- a/roles/node_exporter/templates/node_exporter.service.j2
+++ b/roles/node_exporter/templates/node_exporter.service.j2
@@ -42,6 +42,9 @@ StartLimitInterval=0
 {% for m in ansible_mounts if m.mount.startswith('/home') %}
 {%   set ns.protect_home = 'read-only' %}
 {% endfor %}
+{% if node_exporter_textfile_dir.startswith('/home') %}
+{%   set ns.protect_home = 'read-only' %}
+{% endif %}
 ProtectHome={{ ns.protect_home }}
 NoNewPrivileges=yes
 


### PR DESCRIPTION
Set the node_exporter `ProtectHome=read-only` when the textfile dir is in `/home`.

Fixes: https://github.com/prometheus-community/ansible/issues/183