### PR TITLE
fix(alertmanager): add routes before match_re

### DIFF
--- a/roles/alertmanager/defaults/main.yml
+++ b/roles/alertmanager/defaults/main.yml
@@ -86,6 +86,7 @@ alertmanager_route: {}
 #   receiver: slack
 #   # This routes performs a regular expression match on alert labels to
 #   # catch alerts that are related to a list of services.
+#   routes:
 #     - match_re:
 #         service: ^(foo1|foo2|baz)$
 #       receiver: team-X-mails


### PR DESCRIPTION
When i configuring alertmanager vars, the absence of 'routes' in front of '- match_re' has caused confusion and errors.