### PR TITLE
skip_changelog: temporarily pin molecule version

### DIFF
--- a/tests/integration/molecule.sh
+++ b/tests/integration/molecule.sh
@@ -22,7 +22,7 @@ fi
 
 # Install ansible version specific requirements
 if [ "$(printf '%s\n' "2.12" "$ansible_version" | sort -V | head -n1)" = "2.12" ]; then 
-       python -m pip install molecule molecule-plugins[docker]
+       python -m pip install "molecule<6" molecule-plugins[docker]
        ansible-galaxy collection install git+https://github.com/ansible-collections/community.docker.git
        ansible-galaxy collection install -r "$collection_root/requirements.yml"
 elif [ "$(printf '%s\n' "2.10" "$ansible_version" | sort -V | head -n1)" = "2.10" ]; then


### PR DESCRIPTION
Temporarily avoid molecule 6 as seems to cause issues with our CI tests, probably caused by this: https://github.com/ansible/molecule/pull/3956