### PR TITLE
fix(systemd_exporter): Fix collector flags for older versions

### DIFF
--- a/roles/systemd_exporter/molecule/alternative/molecule.yml
+++ b/roles/systemd_exporter/molecule/alternative/molecule.yml
@@ -7,3 +7,6 @@ provisioner:
         systemd_exporter_web_listen_address: "127.0.0.1:9000"
         go_arch: amd64
         systemd_exporter_version: 0.4.0
+        systemd_exporter_enable_restart_count: true
+        systemd_exporter_enable_ip_accounting: true
+        systemd_exporter_enable_file_descriptor_size: true

--- a/roles/systemd_exporter/molecule/alternative/molecule.yml
+++ b/roles/systemd_exporter/molecule/alternative/molecule.yml
@@ -7,6 +7,4 @@ provisioner:
         systemd_exporter_web_listen_address: "127.0.0.1:9000"
         go_arch: amd64
         systemd_exporter_version: 0.4.0
-        systemd_exporter_enable_restart_count: true
-        systemd_exporter_enable_ip_accounting: true
         systemd_exporter_enable_file_descriptor_size: true

--- a/roles/systemd_exporter/templates/systemd_exporter.service.j2
+++ b/roles/systemd_exporter/templates/systemd_exporter.service.j2
@@ -10,13 +10,25 @@ User={{ systemd_exporter_system_user }}
 Group={{ systemd_exporter_system_group }}
 ExecStart={{ systemd_exporter_binary_install_dir }}/systemd_exporter \
 {% if systemd_exporter_enable_restart_count %}
+    {% if systemd_exporter_version is version('0.5.0', '>=') %}
     --systemd.collector.enable-restart-count \
+    {% else %}
+    --collector.enable-restart-count \
+    {% endif %}
 {% endif %}
 {% if systemd_exporter_enable_file_descriptor_size %}
+    {% if systemd_exporter_version is version('0.5.0', '>=') %}
     --systemd.collector.enable-file-descriptor-size \
+    {% else %}
+    --collector.enable-file-descriptor-size \
+    {% endif %}
 {% endif %}
 {% if systemd_exporter_enable_ip_accounting %}
+    {% if systemd_exporter_version is version('0.5.0', '>=') %}
     --systemd.collector.enable-ip-accounting \
+    {% else %}
+    --collector.enable-ip-accounting \
+    {% endif %}
 {% endif %}
 {% if systemd_exporter_unit_include != ""%}
     --systemd.collector.unit-include={{ systemd_exporter_unit_include }} \


### PR DESCRIPTION
In systemd_exporter 0.5.0, `--systemd.collector` were renamed from `--collector` to `--systemd.collector`.