### PR TITLE
feat(systemd_exporter): Add logging configuration to systemd_exporter

### DIFF
--- a/roles/systemd_exporter/defaults/main.yml
+++ b/roles/systemd_exporter/defaults/main.yml
@@ -19,3 +19,5 @@ systemd_exporter_unit_exclude: ""
 systemd_exporter_binary_install_dir: "/usr/local/bin"
 systemd_exporter_system_group: "systemd-exporter"
 systemd_exporter_system_user: "{{ systemd_exporter_system_group }}"
+
+systemd_exporter_log_level: info

--- a/roles/systemd_exporter/meta/argument_specs.yml
+++ b/roles/systemd_exporter/meta/argument_specs.yml
@@ -65,3 +65,5 @@ argument_specs:
           - "I(Advanced)"
           - "Systemd exporter user"
         default: "systemd-exporter"
+      systemd_exporter_log_level:
+        description: Only log messages with the given severity or above.

--- a/roles/systemd_exporter/templates/systemd_exporter.service.j2
+++ b/roles/systemd_exporter/templates/systemd_exporter.service.j2
@@ -39,6 +39,7 @@ ExecStart={{ systemd_exporter_binary_install_dir }}/systemd_exporter \
 {% if systemd_exporter_tls_server_config | length > 0 %}
     --web.config.file=/etc/systemd_exporter/config.yaml \
 {% endif %}
+    --log.level={{ systemd_exporter_log_level }} \
     --web.listen-address={{ systemd_exporter_web_listen_address }}
 
 SyslogIdentifier=systemd_exporter


### PR DESCRIPTION
Allow configuring the log verbosity of systemd_exporter via systemd_exporter_log_level, corresponding to the --log-level flag.