### PR TITLE
enhancement: allows using multiple web listen addresses

### DIFF
--- a/roles/alertmanager/molecule/alternative/molecule.yml
+++ b/roles/alertmanager/molecule/alternative/molecule.yml
@@ -6,7 +6,9 @@ provisioner:
         alertmanager_binary_local_dir: '/tmp/alertmanager-linux-amd64'
         alertmanager_config_dir: /opt/am/etc
         alertmanager_db_dir: /opt/am/lib
-        alertmanager_web_listen_address: '127.0.0.1:9093'
+        alertmanager_web_listen_address:
+          - '127.0.0.1:9093'
+          - '127.0.1.1:9093'
         alertmanager_web_external_url: 'http://localhost:9093/alertmanager'
         alertmanager_resolve_timeout: 10m
         alertmanager_slack_api_url: "http://example.com"
@@ -31,4 +33,4 @@ provisioner:
           peers:
             - "127.0.0.1:6783"
             - "alertmanager.demo.do.prometheus.io:6783"
-        version: 0.19.0
+        alertmanager_version: 0.25.0

--- a/roles/alertmanager/molecule/alternative/prepare.yml
+++ b/roles/alertmanager/molecule/alternative/prepare.yml
@@ -6,9 +6,9 @@
     - name: Download alertmanager binary to local folder
       become: false
       ansible.builtin.get_url:
-        url: "https://github.com/prometheus/alertmanager/releases/download/v{{ version\
-          \ }}/alertmanager-{{ version }}.linux-amd64.tar.gz"
-        dest: "/tmp/alertmanager-{{ version }}.linux-amd64.tar.gz"
+        url: "https://github.com/prometheus/alertmanager/releases/download/v{{ alertmanager_version\
+          \ }}/alertmanager-{{ alertmanager_version }}.linux-amd64.tar.gz"
+        dest: "/tmp/alertmanager-{{ alertmanager_version }}.linux-amd64.tar.gz"
         mode: 0644
       register: _download_archive
       until: _download_archive is succeeded
@@ -19,15 +19,15 @@
     - name: Unpack alertmanager binaries
       become: false
       ansible.builtin.unarchive:
-        src: "/tmp/alertmanager-{{ version }}.linux-amd64.tar.gz"
+        src: "/tmp/alertmanager-{{ alertmanager_version }}.linux-amd64.tar.gz"
         dest: "/tmp"
-        creates: "/tmp/alertmanager-{{ version }}.linux-amd64/alertmanager"
+        creates: "/tmp/alertmanager-{{ alertmanager_version }}.linux-amd64/alertmanager"
       check_mode: false
 
     - name: Link to alertmanager binaries directory
       become: false
       ansible.builtin.file:
-        src: "/tmp/alertmanager-{{ version }}.linux-amd64"
+        src: "/tmp/alertmanager-{{ alertmanager_version }}.linux-amd64"
         dest: "/tmp/alertmanager-linux-amd64"
         state: link
       check_mode: false

--- a/roles/alertmanager/molecule/alternative/tests/test_alternative.py
+++ b/roles/alertmanager/molecule/alternative/tests/test_alternative.py
@@ -47,7 +47,8 @@ def test_service(host):
 
 @pytest.mark.parametrize("sockets", [
     "tcp://127.0.0.1:9093",
-    "tcp://127.0.0.1:6783"
+    "tcp://127.0.1.1:9093",
+    "tcp://127.0.0.1:6783",
 ])
 def test_socket(host, sockets):
     assert host.socket(sockets).is_listening

--- a/roles/alertmanager/tasks/preflight.yml
+++ b/roles/alertmanager/tasks/preflight.yml
@@ -20,6 +20,27 @@
   ansible.builtin.package_facts:
   when: "not 'packages' in ansible_facts"
 
+- name: Assert that used version supports listen address type
+  ansible.builtin.assert:
+    that:
+      - >-
+        alertmanager_web_listen_address is string
+        or
+        (
+          alertmanager_version is version('0.25.0', '>=') and
+          alertmanager_web_listen_address | type_debug == "list"
+        )
+
+- name: Naive assertion of proper listen address
+  ansible.builtin.assert:
+    that:
+      - >-
+        [alertmanager_web_listen_address] |
+          flatten |
+          reject('match', '.+:\\d+$') |
+          list |
+          length == 0
+
 - name: Discover latest version
   ansible.builtin.set_fact:
     alertmanager_version: "{{ (lookup('url', 'https://api.github.com/repos/prometheus/alertmanager/releases/latest', headers=_github_api_headers,

--- a/roles/alertmanager/templates/alertmanager.service.j2
+++ b/roles/alertmanager/templates/alertmanager.service.j2
@@ -33,7 +33,16 @@ ExecStart={{ _alertmanager_binary_install_dir }}/alertmanager \
 {% endfor %}
   {{ pre }}-config.file={{ alertmanager_config_dir }}/alertmanager.yml \
   {{ pre }}-storage.path={{ alertmanager_db_dir }} \
+{% if alertmanager_version is version('0.25.0', '>=') and
+      alertmanager_web_listen_address is iterable and
+      alertmanager_web_listen_address is not mapping and
+      alertmanager_web_listen_address is not string %}
+{%   for address in alertmanager_web_listen_address %}
+  {{ pre }}-web.listen-address={{ address }} \
+{%   endfor %}
+{% else %}
   {{ pre }}-web.listen-address={{ alertmanager_web_listen_address }} \
+{% endif %}
   {{ pre }}-web.external-url={{ alertmanager_web_external_url }}{% for flag, flag_value in alertmanager_config_flags_extra.items() %} \
   {{ pre }}-{{ flag }}={{ flag_value }}{% endfor %}
 

--- a/roles/blackbox_exporter/molecule/alternative/molecule.yml
+++ b/roles/blackbox_exporter/molecule/alternative/molecule.yml
@@ -3,10 +3,13 @@ provisioner:
   inventory:
     group_vars:
       all:
-        blackbox_exporter_web_listen_address: "127.0.0.1:9000"
+        blackbox_exporter_web_listen_address:
+          - '127.0.0.1:9000'
+          - '127.0.1.1:9000'
         blackbox_exporter_cli_flags:
           log.level: "warn"
         blackbox_exporter_configuration_modules:
           tcp_connect:
             prober: tcp
             timeout: 5s
+        blackbox_exporter_version: 0.23.0

--- a/roles/blackbox_exporter/molecule/alternative/tests/test_alternative.py
+++ b/roles/blackbox_exporter/molecule/alternative/tests/test_alternative.py
@@ -33,6 +33,9 @@ def test_service(host):
         raise  # Re-raise the original assertion error
 
 
-def test_socket(host):
-    s = host.socket("tcp://127.0.0.1:9000")
-    assert s.is_listening
+@pytest.mark.parametrize("sockets", [
+    "tcp://127.0.0.1:9000",
+    "tcp://127.0.1.1:9000",
+])
+def test_socket(host, sockets):
+    assert host.socket(sockets).is_listening

--- a/roles/blackbox_exporter/tasks/preflight.yml
+++ b/roles/blackbox_exporter/tasks/preflight.yml
@@ -20,10 +20,26 @@
   ansible.builtin.package_facts:
   when: "not 'packages' in ansible_facts"
 
+- name: Assert that used version supports listen address type
+  ansible.builtin.assert:
+    that:
+      - >-
+        blackbox_exporter_web_listen_address is string
+        or
+        (
+          blackbox_exporter_version is version('0.23.0', '>=') and
+          blackbox_exporter_web_listen_address | type_debug == "list"
+        )
+
 - name: Naive assertion of proper listen address
   ansible.builtin.assert:
     that:
-      - "':' in blackbox_exporter_web_listen_address"
+      - >-
+        [blackbox_exporter_web_listen_address] |
+          flatten |
+          reject('match', '.+:\\d+$') |
+          list |
+          length == 0
 
 - name: Discover latest version
   ansible.builtin.set_fact:

--- a/roles/blackbox_exporter/templates/blackbox_exporter.service.j2
+++ b/roles/blackbox_exporter/templates/blackbox_exporter.service.j2
@@ -16,7 +16,16 @@ ExecStart=/usr/local/bin/blackbox_exporter \
   {% for flag, flag_value in blackbox_exporter_cli_flags.items() -%}
   --{{ flag }}={{ flag_value }} \
   {% endfor -%}
+{% if blackbox_exporter_version is version('0.23.0', '>=') and
+      blackbox_exporter_web_listen_address is iterable and
+      blackbox_exporter_web_listen_address is not mapping and
+      blackbox_exporter_web_listen_address is not string %}
+{%   for address in blackbox_exporter_web_listen_address %}
+  --web.listen-address={{ address }}{{ " \\" if not loop.last else "" }}
+{%   endfor %}
+{% else %}
   --web.listen-address={{ blackbox_exporter_web_listen_address }}
+{% endif %}
 
 SyslogIdentifier=blackbox_exporter
 KillMode=process

--- a/roles/chrony_exporter/molecule/alternative/molecule.yml
+++ b/roles/chrony_exporter/molecule/alternative/molecule.yml
@@ -4,7 +4,9 @@ provisioner:
     group_vars:
       all:
         chrony_exporter_binary_local_dir: "/tmp/chrony_exporter-linux-amd64"
-        chrony_exporter_web_listen_address: "127.0.0.1:8080"
+        chrony_exporter_web_listen_address:
+          - '127.0.0.1:8080'
+          - '127.0.1.1:8080'
         chrony_exporter_enabled_collectors:
           - sources
         chrony_exporter_disabled_collectors:

--- a/roles/chrony_exporter/molecule/alternative/tests/test_alternative.py
+++ b/roles/chrony_exporter/molecule/alternative/tests/test_alternative.py
@@ -3,6 +3,7 @@ __metaclass__ = type
 
 import os
 import testinfra.utils.ansible_runner
+import pytest
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
@@ -37,10 +38,9 @@ def test_protecthome_property(host):
     assert p.get("ProtectHome") == "yes"
 
 
-def test_socket(host):
-    sockets = [
-        "tcp://127.0.0.1:8080"
-    ]
-    for socket in sockets:
-        s = host.socket(socket)
-        assert s.is_listening
+@pytest.mark.parametrize("sockets", [
+    "tcp://127.0.0.1:8080",
+    "tcp://127.0.1.1:8080",
+])
+def test_socket(host, sockets):
+    assert host.socket(sockets).is_listening

--- a/roles/chrony_exporter/tasks/preflight.yml
+++ b/roles/chrony_exporter/tasks/preflight.yml
@@ -20,10 +20,26 @@
   ansible.builtin.package_facts:
   when: "not 'packages' in ansible_facts"
 
+- name: Assert that used version supports listen address type
+  ansible.builtin.assert:
+    that:
+      - >-
+        chrony_exporter_web_listen_address is string
+        or
+        (
+          chrony_exporter_version is version('0.5.0', '>=') and
+          chrony_exporter_web_listen_address | type_debug == "list"
+        )
+
 - name: Naive assertion of proper listen address
   ansible.builtin.assert:
     that:
-      - "':' in chrony_exporter_web_listen_address"
+      - >-
+        [chrony_exporter_web_listen_address] |
+          flatten |
+          reject('match', '.+:\\d+$') |
+          list |
+          length == 0
 
 - name: Assert collectors are not both disabled and enabled at the same time
   ansible.builtin.assert:

--- a/roles/chrony_exporter/templates/chrony_exporter.service.j2
+++ b/roles/chrony_exporter/templates/chrony_exporter.service.j2
@@ -26,7 +26,16 @@ ExecStart={{ chrony_exporter_binary_install_dir }}/chrony_exporter \
 {% if chrony_exporter_tls_server_config | length > 0 or chrony_exporter_http_server_config | length > 0 or chrony_exporter_basic_auth_users | length > 0 %}
     '--web.config.file=/etc/chrony_exporter/web_config.yaml' \
 {% endif %}
+{% if chrony_exporter_version is version('0.5.0', '>=') and
+      chrony_exporter_web_listen_address is iterable and
+      chrony_exporter_web_listen_address is not mapping and
+      chrony_exporter_web_listen_address is not string %}
+{%   for address in chrony_exporter_web_listen_address %}
+    '--web.listen-address={{ address }}' \
+{%   endfor %}
+{% else %}
     '--web.listen-address={{ chrony_exporter_web_listen_address }}' \
+{% endif %}
     '--web.telemetry-path={{ chrony_exporter_web_telemetry_path }}'
 
 SyslogIdentifier=chrony_exporter

--- a/roles/mysqld_exporter/molecule/alternative/molecule.yml
+++ b/roles/mysqld_exporter/molecule/alternative/molecule.yml
@@ -4,7 +4,9 @@ provisioner:
     group_vars:
       all:
         mysqld_exporter_binary_local_dir: "/tmp/mysqld_exporter-linux-amd64"
-        mysqld_exporter_web_listen_address: "127.0.0.1:8080"
+        mysqld_exporter_web_listen_address:
+          - '127.0.0.1:8080'
+          - '127.0.1.1:8080'
         mysqld_exporter_enabled_collectors:
           - slave_hosts
         mysqld_exporter_disabled_collectors:
@@ -18,4 +20,4 @@ provisioner:
         mysqld_exporter_basic_auth_users:
           randomuser: examplepassword
         go_arch: amd64
-        mysqld_exporter_version: 0.13.0
+        mysqld_exporter_version: 0.15.0

--- a/roles/mysqld_exporter/molecule/alternative/tests/test_alternative.py
+++ b/roles/mysqld_exporter/molecule/alternative/tests/test_alternative.py
@@ -3,6 +3,7 @@ __metaclass__ = type
 
 import os
 import testinfra.utils.ansible_runner
+import pytest
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
@@ -21,10 +22,9 @@ def test_service(host):
         raise  # Re-raise the original assertion error
 
 
-def test_socket(host):
-    sockets = [
-        "tcp://127.0.0.1:8080"
-    ]
-    for socket in sockets:
-        s = host.socket(socket)
-        assert s.is_listening
+@pytest.mark.parametrize("sockets", [
+    "tcp://127.0.0.1:8080",
+    "tcp://127.0.1.1:8080",
+])
+def test_socket(host, sockets):
+    assert host.socket(sockets).is_listening

--- a/roles/mysqld_exporter/tasks/preflight.yml
+++ b/roles/mysqld_exporter/tasks/preflight.yml
@@ -20,10 +20,26 @@
   ansible.builtin.package_facts:
   when: "not 'packages' in ansible_facts"
 
+- name: Assert that used version supports listen address type
+  ansible.builtin.assert:
+    that:
+      - >-
+        mysqld_exporter_web_listen_address is string
+        or
+        (
+          mysqld_exporter_version is version('0.15.0', '>=') and
+          mysqld_exporter_web_listen_address | type_debug == "list"
+        )
+
 - name: Naive assertion of proper listen address
   ansible.builtin.assert:
     that:
-      - "':' in mysqld_exporter_web_listen_address"
+      - >-
+        [mysqld_exporter_web_listen_address] |
+          flatten |
+          reject('match', '.+:\\d+$') |
+          list |
+          length == 0
 
 - name: Assert collectors are not both disabled and enabled at the same time
   ansible.builtin.assert:

--- a/roles/mysqld_exporter/templates/mysqld_exporter.service.j2
+++ b/roles/mysqld_exporter/templates/mysqld_exporter.service.j2
@@ -26,7 +26,16 @@ ExecStart={{ mysqld_exporter_binary_install_dir }}/mysqld_exporter \
 {% if mysqld_exporter_tls_server_config | length > 0 or mysqld_exporter_http_server_config | length > 0 or mysqld_exporter_basic_auth_users | length > 0 %}
     --web.config.file={{ mysqld_exporter_config_dir }}/web_config.yaml \
 {% endif %}
+{% if mysqld_exporter_version is version('0.15.0', '>=') and
+      mysqld_exporter_web_listen_address is iterable and
+      mysqld_exporter_web_listen_address is not mapping and
+      mysqld_exporter_web_listen_address is not string %}
+{%   for address in mysqld_exporter_web_listen_address %}
+    --web.listen-address={{ address }} \
+{%   endfor %}
+{% else %}
     --web.listen-address={{ mysqld_exporter_web_listen_address }} \
+{% endif %}
     --web.telemetry-path={{ mysqld_exporter_web_telemetry_path }} \
     --config.my-cnf={{ mysqld_exporter_config_dir }}/{{ mysqld_exporter_config_file }}
 

--- a/roles/node_exporter/molecule/alternative/molecule.yml
+++ b/roles/node_exporter/molecule/alternative/molecule.yml
@@ -4,7 +4,9 @@ provisioner:
     group_vars:
       all:
         node_exporter_binary_local_dir: "/tmp/node_exporter-linux-amd64"
-        node_exporter_web_listen_address: "127.0.0.1:8080"
+        node_exporter_web_listen_address:
+          - '127.0.0.1:8080'
+          - '127.0.1.1:8080'
         node_exporter_textfile_dir: ""
         node_exporter_enabled_collectors:
           - entropy
@@ -19,4 +21,4 @@ provisioner:
         node_exporter_basic_auth_users:
           randomuser: examplepassword
         go_arch: amd64
-        node_exporter_version: 1.0.0
+        node_exporter_version: 1.5.0

--- a/roles/node_exporter/molecule/alternative/tests/test_alternative.py
+++ b/roles/node_exporter/molecule/alternative/tests/test_alternative.py
@@ -3,6 +3,7 @@ __metaclass__ = type
 
 import os
 import testinfra.utils.ansible_runner
+import pytest
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
@@ -36,10 +37,9 @@ def test_protecthome_property(host):
     assert p.get("ProtectHome") == "yes"
 
 
-def test_socket(host):
-    sockets = [
-        "tcp://127.0.0.1:8080"
-    ]
-    for socket in sockets:
-        s = host.socket(socket)
-        assert s.is_listening
+@pytest.mark.parametrize("sockets", [
+    "tcp://127.0.0.1:8080",
+    "tcp://127.0.1.1:8080",
+])
+def test_socket(host, sockets):
+    assert host.socket(sockets).is_listening

--- a/roles/node_exporter/tasks/preflight.yml
+++ b/roles/node_exporter/tasks/preflight.yml
@@ -20,10 +20,26 @@
   ansible.builtin.package_facts:
   when: "not 'packages' in ansible_facts"
 
+- name: Assert that used version supports listen address type
+  ansible.builtin.assert:
+    that:
+      - >-
+        node_exporter_web_listen_address is string
+        or
+        (
+          node_exporter_version is version('1.5.0', '>=') and
+          node_exporter_web_listen_address | type_debug == "list"
+        )
+
 - name: Naive assertion of proper listen address
   ansible.builtin.assert:
     that:
-      - "':' in node_exporter_web_listen_address"
+      - >-
+        [node_exporter_web_listen_address] |
+          flatten |
+          reject('match', '.+:\\d+$') |
+          list |
+          length == 0
 
 - name: Assert collectors are not both disabled and enabled at the same time
   ansible.builtin.assert:

--- a/roles/node_exporter/templates/node_exporter.service.j2
+++ b/roles/node_exporter/templates/node_exporter.service.j2
@@ -30,7 +30,16 @@ ExecStart={{ node_exporter_binary_install_dir }}/node_exporter \
     '--web.config=/etc/node_exporter/config.yaml' \
     {% endif %}
 {% endif %}
+{% if node_exporter_version is version('1.5.0', '>=') and
+      node_exporter_web_listen_address is iterable and
+      node_exporter_web_listen_address is not mapping and
+      node_exporter_web_listen_address is not string %}
+{%   for address in node_exporter_web_listen_address %}
+    '--web.listen-address={{ address }}' \
+{%   endfor %}
+{% else %}
     '--web.listen-address={{ node_exporter_web_listen_address }}' \
+{% endif %}
     '--web.telemetry-path={{ node_exporter_web_telemetry_path }}'
 
 SyslogIdentifier=node_exporter

--- a/roles/prometheus/molecule/alternative/molecule.yml
+++ b/roles/prometheus/molecule/alternative/molecule.yml
@@ -86,5 +86,5 @@ provisioner:
                 target_label: instance
               - target_label: __address__
                 replacement: 127.0.0.1:9115  # Blackbox exporter.
-        version: 2.25.2
+        prometheus_version: 2.25.2
         prometheus_stop_timeout: 1min

--- a/roles/prometheus/molecule/alternative/prepare.yml
+++ b/roles/prometheus/molecule/alternative/prepare.yml
@@ -6,9 +6,9 @@
     - name: Download prometheus binary to local folder
       become: false
       ansible.builtin.get_url:
-        url: "https://github.com/prometheus/prometheus/releases/download/v{{ version\
-          \ }}/prometheus-{{ version }}.linux-amd64.tar.gz"
-        dest: "/tmp/prometheus-{{ version }}.linux-amd64.tar.gz"
+        url: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version\
+          \ }}/prometheus-{{ prometheus_version }}.linux-amd64.tar.gz"
+        dest: "/tmp/prometheus-{{ prometheus_version }}.linux-amd64.tar.gz"
         mode: 0644
       register: _download_archive
       until: _download_archive is succeeded
@@ -19,15 +19,15 @@
     - name: Unpack prometheus binaries
       become: false
       ansible.builtin.unarchive:
-        src: "/tmp/prometheus-{{ version }}.linux-amd64.tar.gz"
+        src: "/tmp/prometheus-{{ prometheus_version }}.linux-amd64.tar.gz"
         dest: "/tmp"
-        creates: "/tmp/prometheus-{{ version }}.linux-amd64/prometheus"
+        creates: "/tmp/prometheus-{{ prometheus_version }}.linux-amd64/prometheus"
       check_mode: false
 
     - name: Link to prometheus binaries directory
       become: false
       ansible.builtin.file:
-        src: "/tmp/prometheus-{{ version }}.linux-amd64"
+        src: "/tmp/prometheus-{{ prometheus_version }}.linux-amd64"
         dest: "/tmp/prometheus-linux-amd64"
         state: link
       check_mode: false

--- a/roles/prometheus/molecule/alternative/tests/test_alternative.py
+++ b/roles/prometheus/molecule/alternative/tests/test_alternative.py
@@ -65,6 +65,8 @@ def test_service(host):
         raise  # Re-raise the original assertion error
 
 
-def test_socket(host):
-    s = host.socket("tcp://127.0.0.1:9090")
-    assert s.is_listening
+@pytest.mark.parametrize("sockets", [
+    "tcp://127.0.0.1:9090",
+])
+def test_socket(host, sockets):
+    assert host.socket(sockets).is_listening

--- a/roles/prometheus/tasks/preflight.yml
+++ b/roles/prometheus/tasks/preflight.yml
@@ -20,6 +20,22 @@
   ansible.builtin.package_facts:
   when: "not 'packages' in ansible_facts"
 
+- name: Assert that used version supports listen address type
+  ansible.builtin.assert:
+    that:
+      - >-
+        prometheus_web_listen_address is string
+
+- name: Naive assertion of proper listen address
+  ansible.builtin.assert:
+    that:
+      - >-
+        [prometheus_web_listen_address] |
+          flatten |
+          reject('match', '.+:\\d+$') |
+          list |
+          length == 0
+
 - name: Assert no duplicate config flags
   ansible.builtin.assert:
     that:

--- a/roles/pushgateway/molecule/alternative/molecule.yml
+++ b/roles/pushgateway/molecule/alternative/molecule.yml
@@ -4,7 +4,9 @@ provisioner:
     group_vars:
       all:
         pushgateway_binary_local_dir: "/tmp/pushgateway-linux-amd64"
-        pushgateway_web_listen_address: "127.0.0.1:8080"
+        pushgateway_web_listen_address:
+          - '127.0.0.1:8080'
+          - '127.0.1.1:8080'
         pushgateway_tls_server_config:
           cert_file: /etc/pushgateway/tls.cert
           key_file: /etc/pushgateway/tls.key

--- a/roles/pushgateway/molecule/alternative/tests/test_alternative.py
+++ b/roles/pushgateway/molecule/alternative/tests/test_alternative.py
@@ -3,6 +3,7 @@ __metaclass__ = type
 
 import os
 import testinfra.utils.ansible_runner
+import pytest
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
@@ -37,10 +38,9 @@ def test_protecthome_property(host):
     assert p.get("ProtectHome") == "yes"
 
 
-def test_socket(host):
-    sockets = [
-        "tcp://127.0.0.1:8080"
-    ]
-    for socket in sockets:
-        s = host.socket(socket)
-        assert s.is_listening
+@pytest.mark.parametrize("sockets", [
+    "tcp://127.0.0.1:8080",
+    "tcp://127.0.1.1:8080",
+])
+def test_socket(host, sockets):
+    assert host.socket(sockets).is_listening

--- a/roles/pushgateway/tasks/preflight.yml
+++ b/roles/pushgateway/tasks/preflight.yml
@@ -20,10 +20,26 @@
   ansible.builtin.package_facts:
   when: "not 'packages' in ansible_facts"
 
+- name: Assert that used version supports listen address type
+  ansible.builtin.assert:
+    that:
+      - >-
+        pushgateway_web_listen_address is string
+        or
+        (
+          pushgateway_version is version('1.5.0', '>=') and
+          pushgateway_web_listen_address | type_debug == "list"
+        )
+
 - name: Naive assertion of proper listen address
   ansible.builtin.assert:
     that:
-      - "':' in pushgateway_web_listen_address"
+      - >-
+        [pushgateway_web_listen_address] |
+          flatten |
+          reject('match', '.+:\\d+$') |
+          list |
+          length == 0
 
 - name: Assert that TLS config is correct
   when: pushgateway_tls_server_config | length > 0

--- a/roles/pushgateway/templates/pushgateway.service.j2
+++ b/roles/pushgateway/templates/pushgateway.service.j2
@@ -16,7 +16,16 @@ ExecStart={{ pushgateway_binary_install_dir }}/pushgateway \
     '--web.config=/etc/pushgateway/web_config.yml' \
     {% endif %}
 {% endif %}
+{% if pushgateway_version is version('1.5.0', '>=') and
+      pushgateway_web_listen_address is iterable and
+      pushgateway_web_listen_address is not mapping and
+      pushgateway_web_listen_address is not string %}
+{%   for address in pushgateway_web_listen_address %}
+    '--web.listen-address={{ address }}' \
+{%   endfor %}
+{% else %}
     '--web.listen-address={{ pushgateway_web_listen_address }}' \
+{% endif %}
     '--web.telemetry-path={{ pushgateway_web_telemetry_path }}'
 
 SyslogIdentifier=pushgateway

--- a/roles/smartctl_exporter/tasks/preflight.yml
+++ b/roles/smartctl_exporter/tasks/preflight.yml
@@ -20,10 +20,21 @@
   ansible.builtin.package_facts:
   when: "not 'packages' in ansible_facts"
 
+- name: Assert that used version supports listen address type
+  ansible.builtin.assert:
+    that:
+      - >-
+        smartctl_exporter_web_listen_address is string
+
 - name: Naive assertion of proper listen address
   ansible.builtin.assert:
     that:
-      - "':' in smartctl_exporter_web_listen_address"
+      - >-
+        [smartctl_exporter_web_listen_address] |
+          flatten |
+          reject('match', '.+:\\d+$') |
+          list |
+          length == 0
 
 - name: Assert that TLS config is correct
   when: smartctl_exporter_tls_server_config | length > 0

--- a/roles/smokeping_prober/defaults/main.yml
+++ b/roles/smokeping_prober/defaults/main.yml
@@ -6,7 +6,7 @@ smokeping_prober_binary_url: "https://github.com/{{ _smokeping_prober_repo }}/re
 smokeping_prober_checksums_url: "https://github.com/{{ _smokeping_prober_repo }}/releases/download/v{{ smokeping_prober_version }}/sha256sums.txt"
 smokeping_prober_skip_install: false
 
-smokeping_prober_web_listen_address: ":9374"
+smokeping_prober_web_listen_address: "0.0.0.0:9374"
 smokeping_prober_web_telemetry_path: "/metrics"
 
 # List of smokeping_prober targets.

--- a/roles/smokeping_prober/molecule/alternative/molecule.yml
+++ b/roles/smokeping_prober/molecule/alternative/molecule.yml
@@ -4,7 +4,9 @@ provisioner:
     group_vars:
       all:
         smokeping_prober_binary_local_dir: "/tmp/smokeping_prober-linux-amd64"
-        smokeping_prober_web_listen_address: "127.0.0.1:8080"
+        smokeping_prober_web_listen_address:
+          - '127.0.0.1:8080'
+          - '127.0.1.1:8080'
         smokeping_prober_tls_server_config:
           cert_file: /etc/smokeping_prober/tls.cert
           key_file: /etc/smokeping_prober/tls.key
@@ -13,4 +15,4 @@ provisioner:
         smokeping_prober_basic_auth_users:
           randomuser: examplepassword
         go_arch: amd64
-        smokeping_prober_version: 0.6.1
+        smokeping_prober_version: 0.7.0

--- a/roles/smokeping_prober/molecule/alternative/tests/test_alternative.py
+++ b/roles/smokeping_prober/molecule/alternative/tests/test_alternative.py
@@ -3,6 +3,7 @@ __metaclass__ = type
 
 import os
 import testinfra.utils.ansible_runner
+import pytest
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
@@ -37,10 +38,9 @@ def test_protecthome_property(host):
     assert p.get("ProtectHome") == "yes"
 
 
-def test_socket(host):
-    sockets = [
-        "tcp://127.0.0.1:8080"
-    ]
-    for socket in sockets:
-        s = host.socket(socket)
-        assert s.is_listening
+@pytest.mark.parametrize("sockets", [
+    "tcp://127.0.0.1:8080",
+    "tcp://127.0.1.1:8080",
+])
+def test_socket(host, sockets):
+    assert host.socket(sockets).is_listening

--- a/roles/smokeping_prober/tasks/preflight.yml
+++ b/roles/smokeping_prober/tasks/preflight.yml
@@ -20,10 +20,26 @@
   ansible.builtin.package_facts:
   when: "not 'packages' in ansible_facts"
 
+- name: Assert that used version supports listen address type
+  ansible.builtin.assert:
+    that:
+      - >-
+        smokeping_prober_web_listen_address is string
+        or
+        (
+          smokeping_prober_version is version('0.7.0', '>=') and
+          smokeping_prober_web_listen_address | type_debug == "list"
+        )
+
 - name: Naive assertion of proper listen address
   ansible.builtin.assert:
     that:
-      - "':' in smokeping_prober_web_listen_address"
+      - >-
+        [smokeping_prober_web_listen_address] |
+          flatten |
+          reject('match', '.+:\\d+$') |
+          list |
+          length == 0
 
 - name: Assert that TLS config is correct
   when: smokeping_prober_tls_server_config | length > 0

--- a/roles/smokeping_prober/templates/smokeping_prober.service.j2
+++ b/roles/smokeping_prober/templates/smokeping_prober.service.j2
@@ -13,7 +13,16 @@ PermissionsStartOnly=true
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStart={{ smokeping_prober_binary_install_dir }}/smokeping_prober \
   --config.file={{ smokeping_prober_config_dir }}//{{ smokeping_prober_config_file }} \
+{% if smokeping_prober_version is version('0.7.0', '>=') and
+      smokeping_prober_web_listen_address is iterable and
+      smokeping_prober_web_listen_address is not mapping and
+      smokeping_prober_web_listen_address is not string %}
+{%   for address in smokeping_prober_web_listen_address %}
+  --web.listen-address={{ address }}{{ " \\" if not loop.last else "" }}
+{%   endfor %}
+{% else %}
   --web.listen-address={{ smokeping_prober_web_listen_address }}
+{% endif %}
 
 SyslogIdentifier=smokeping_prober
 KillMode=process

--- a/roles/snmp_exporter/molecule/alternative/molecule.yml
+++ b/roles/snmp_exporter/molecule/alternative/molecule.yml
@@ -3,5 +3,7 @@ provisioner:
   inventory:
     group_vars:
       all:
-        snmp_exporter_web_listen_address: "127.0.0.1:9116"
+        snmp_exporter_web_listen_address:
+          - '127.0.0.1:9116'
+          - '127.0.1.1:9116'
         snmp_exporter_config_file: ${MOLECULE_SCENARIO_DIRECTORY}/templates/snmp.yml

--- a/roles/snmp_exporter/molecule/alternative/tests/test_alternative.py
+++ b/roles/snmp_exporter/molecule/alternative/tests/test_alternative.py
@@ -33,6 +33,9 @@ def test_service(host):
         raise  # Re-raise the original assertion error
 
 
-def test_socket(host):
-    s = host.socket("tcp://127.0.0.1:9116")
-    assert s.is_listening
+@pytest.mark.parametrize("sockets", [
+    "tcp://127.0.0.1:9116",
+    "tcp://127.0.1.1:9116",
+])
+def test_socket(host, sockets):
+    assert host.socket(sockets).is_listening

--- a/roles/snmp_exporter/tasks/preflight.yml
+++ b/roles/snmp_exporter/tasks/preflight.yml
@@ -1,4 +1,26 @@
 ---
+
+- name: Assert that used version supports listen address type
+  ansible.builtin.assert:
+    that:
+      - >-
+        snmp_exporter_web_listen_address is string
+        or
+        (
+          snmp_exporter_version is version('0.21.0', '>=') and
+          snmp_exporter_web_listen_address | type_debug == "list"
+        )
+
+- name: Naive assertion of proper listen address
+  ansible.builtin.assert:
+    that:
+      - >-
+        [snmp_exporter_web_listen_address] |
+          flatten |
+          reject('match', '.+:\\d+$') |
+          list |
+          length == 0
+
 - name: Discover latest version
   ansible.builtin.set_fact:
     snmp_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/prometheus/snmp_exporter/releases/latest', headers=_github_api_headers,

--- a/roles/snmp_exporter/templates/snmp_exporter.service.j2
+++ b/roles/snmp_exporter/templates/snmp_exporter.service.j2
@@ -9,7 +9,16 @@ User=nobody
 Group={{ 'nogroup' if ansible_os_family == 'Debian' else 'nobody' }}
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/usr/local/bin/snmp_exporter \
+{% if snmp_exporter_version is version('0.21.0', '>=') and
+      snmp_exporter_web_listen_address is iterable and
+      snmp_exporter_web_listen_address is not mapping and
+      snmp_exporter_web_listen_address is not string %}
+{%   for address in snmp_exporter_web_listen_address %}
+  --web.listen-address={{ address }} \
+{%   endfor %}
+{% else %}
   --web.listen-address={{ snmp_exporter_web_listen_address }} \
+{% endif %}
   --log.level={{ snmp_exporter_log_level }} \
   --config.file=/etc/snmp_exporter/snmp.yml
 

--- a/roles/systemd_exporter/tasks/preflight.yml
+++ b/roles/systemd_exporter/tasks/preflight.yml
@@ -20,10 +20,21 @@
   ansible.builtin.package_facts:
   when: "not 'packages' in ansible_facts"
 
+- name: Assert that used version supports listen address type
+  ansible.builtin.assert:
+    that:
+      - >-
+        systemd_exporter_web_listen_address is string
+
 - name: Naive assertion of proper listen address
   ansible.builtin.assert:
     that:
-      - "':' in systemd_exporter_web_listen_address"
+      - >-
+        [systemd_exporter_web_listen_address] |
+          flatten |
+          reject('match', '.+:\\d+$') |
+          list |
+          length == 0
 
 - name: Assert that TLS config is correct
   when: systemd_exporter_tls_server_config | length > 0


### PR DESCRIPTION
these variants should work now:

```yml
alertmanager_web_listen_address: '127.0.0.1:9093'

alertmanager_web_listen_address:
  - '127.0.0.1:9093'
  - '127.0.1.1:9093'
```

---

fixes #115