### PR TITLE
minor(prometheus): Move prometheus systemd unit task to configure

### DIFF
--- a/roles/prometheus/tasks/configure.yml
+++ b/roles/prometheus/tasks/configure.yml
@@ -70,3 +70,13 @@
     group: prometheus
     mode: 0640
   with_fileglob: "{{ prometheus_static_targets_files }}"
+
+- name: Create systemd service unit
+  ansible.builtin.template:
+    src: prometheus.service.j2
+    dest: /etc/systemd/system/prometheus.service
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - restart prometheus

--- a/roles/prometheus/tasks/install.yml
+++ b/roles/prometheus/tasks/install.yml
@@ -106,16 +106,6 @@
   notify:
     - restart prometheus
 
-- name: Create systemd service unit
-  ansible.builtin.template:
-    src: prometheus.service.j2
-    dest: /etc/systemd/system/prometheus.service
-    owner: root
-    group: root
-    mode: 0644
-  notify:
-    - restart prometheus
-
 - name: Install SELinux dependencies
   ansible.builtin.package:
     name: "{{ _prometheus_selinux_packages }}"


### PR DESCRIPTION
This ensures it's part of the prometheus_configure tag, and is in line with other roles in the collection.