### PR TITLE
feat: allow overriding _prometheus_binary_install_dir

### DIFF
--- a/roles/prometheus/defaults/main.yml
+++ b/roles/prometheus/defaults/main.yml
@@ -5,6 +5,7 @@ prometheus_binary_url: "https://github.com/{{ _prometheus_repo }}/releases/downl
                         prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
 prometheus_checksums_url: "https://github.com/{{ _prometheus_repo }}/releases/download/v{{ prometheus_version }}/sha256sums.txt"
 prometheus_skip_install: false
+_prometheus_binary_install_dir: '/usr/local/bin'
 
 prometheus_config_dir: /etc/prometheus
 prometheus_db_dir: /var/lib/prometheus

--- a/roles/prometheus/vars/main.yml
+++ b/roles/prometheus/vars/main.yml
@@ -7,7 +7,6 @@ go_arch_map:
   armv6l: 'armv6'
 
 go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
-_prometheus_binary_install_dir: '/usr/local/bin'
 
 _prometheus_selinux_packages: "{{ ['libselinux-python', 'policycoreutils-python']
                                if ansible_python_version is version('3', '<') else


### PR DESCRIPTION
This is not ideal as the variable is still prefixed with `_` but it beats the current situation where it cannot be overriden at all.

See #221