### PR TITLE
skip_changelog: Add community.docker collection

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,7 @@
 ---
 collections:
+  - name: https://github.com/ansible-collections/community.docker.git
+    type: git
   - name: https://github.com/ansible-collections/community.general.git
     type: git
   - name: https://github.com/ansible-collections/community.crypto.git


### PR DESCRIPTION
Add Ansible community.docker collection to the requirements to make sure it gets installed with git. Fixes install breakage due to Galaxy API changes.