### PR TITLE
fix(molecule): don't contact galaxy api since requirements come from git

### DIFF
--- a/.config/molecule/config.yml
+++ b/.config/molecule/config.yml
@@ -1,6 +1,7 @@
 ---
 dependency:
   name: galaxy
+prerun: false
 driver:
   name: docker
 platforms:


### PR DESCRIPTION
I thought we had already avoided contacting the ansible galaxy api when switching requirements.yml over to git repos, but apparently molecule has a couple of ways it's installing dependencies, one which is controlled by the "dependency" key in the molecule config, and the other one that via the "prerun" option. The prerun uses ansible-compat and we can't pass any configuration to it, so the only option is to disable it.

By avoiding the galaxy api we can safely use older ansible versions which are incompatible with the ansible galaxy v3 api. 
This should also speed up testing a bit, since we're not installing dependencies multiple times per run.