### PR TITLE
skip_changelog: allow running publish workflow manually

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - '*'
+  workflow_dispatch:
 
 jobs:
   release:


### PR DESCRIPTION
Perhaps a good idea to be able to publish manually in case the galaxy api is acting up.