### PR TITLE
skip_changelog(ci): make sure pytest and pytest-testinfra versions stay compatible

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
 molecule
 docker
+pytest
 pytest-testinfra
 selinux
 passlib

--- a/tests/integration/molecule.sh
+++ b/tests/integration/molecule.sh
@@ -13,11 +13,11 @@ apt -y install docker.io
 
 # Install test requirements from role
 if [ -f "$role_root/test-requirements.txt"  ]; then
-	python -m pip install -r "$role_root/test-requirements.txt"
+	python -m pip install --upgrade -r "$role_root/test-requirements.txt"
 fi
 # Install test requirements from collection
 if [ -f "$collection_root/test-requirements.txt"  ]; then
-	python -m pip install -r "$collection_root/test-requirements.txt"
+	python -m pip install --upgrade -r "$collection_root/test-requirements.txt"
 fi
 
 # Install ansible version specific requirements


### PR DESCRIPTION
Testinfra tests are failing on python 3.9 since testinfra v10.0.0.
https://github.com/prometheus-community/ansible/actions/runs/6906336970/job/18791174950

Seems to be caused by a old version of pytest already being installed on the ci image, this should update pytest and fix the issue.
