### PR TITLE
feat(blackbox_exporter): Create config directory

### DIFF
--- a/roles/blackbox_exporter/defaults/main.yml
+++ b/roles/blackbox_exporter/defaults/main.yml
@@ -72,6 +72,6 @@ blackbox_exporter_configuration_modules:
 #        fail_if_matches_regexp: [test]
 
 # Where to put the blackbox_exporter.yml main configuration file
-blackbox_exporter_config_dir: /etc
+blackbox_exporter_config_dir: /etc/blackbox_exporter
 
 blackbox_exporter_binary_install_dir: "/usr/local/bin"

--- a/roles/blackbox_exporter/molecule/alternative/tests/test_alternative.py
+++ b/roles/blackbox_exporter/molecule/alternative/tests/test_alternative.py
@@ -10,7 +10,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 @pytest.mark.parametrize("files", [
-    "/etc/blackbox_exporter.yml",
+    "/etc/blackbox_exporter/blackbox_exporter.yml",
     "/etc/systemd/system/blackbox_exporter.service",
     "/usr/local/bin/blackbox_exporter"
 ])

--- a/roles/blackbox_exporter/molecule/default/tests/test_default.py
+++ b/roles/blackbox_exporter/molecule/default/tests/test_default.py
@@ -10,7 +10,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 @pytest.mark.parametrize("files", [
-    "/etc/blackbox_exporter.yml",
+    "/etc/blackbox_exporter/blackbox_exporter.yml",
     "/etc/systemd/system/blackbox_exporter.service",
     "/usr/local/bin/blackbox_exporter"
 ])

--- a/roles/blackbox_exporter/tasks/configure.yml
+++ b/roles/blackbox_exporter/tasks/configure.yml
@@ -9,6 +9,14 @@
   notify:
     - restart blackbox_exporter
 
+- name: Create blackbox_exporter config directory
+  ansible.builtin.file:
+    path: "{{ blackbox_exporter_config_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: u+rwX,g+rwX,o=rX
+
 - name: Configure blackbox exporter
   ansible.builtin.template:
     src: blackbox_exporter.yml.j2


### PR DESCRIPTION
Follow the pattern of other exporters and create the configuration file in `/etc/blackbox_exporter` by default.