### PR TITLE
fix: Use repo var for preflight

### DIFF
--- a/roles/alertmanager/tasks/preflight.yml
+++ b/roles/alertmanager/tasks/preflight.yml
@@ -43,7 +43,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    alertmanager_version: "{{ (lookup('url', 'https://api.github.com/repos/prometheus/alertmanager/releases/latest', headers=_github_api_headers,
+    alertmanager_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _alertmanager_repo }}/releases/latest', headers=_github_api_headers,
                            split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: alertmanager_version is version('0.0.0', '>=')

--- a/roles/blackbox_exporter/tasks/preflight.yml
+++ b/roles/blackbox_exporter/tasks/preflight.yml
@@ -43,7 +43,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    blackbox_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/prometheus/blackbox_exporter/releases/latest', headers=_github_api_headers,
+    blackbox_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _blackbox_exporter_repo }}/releases/latest', headers=_github_api_headers,
                             split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: blackbox_exporter_version is version('0.0.0', '>=')

--- a/roles/chrony_exporter/tasks/preflight.yml
+++ b/roles/chrony_exporter/tasks/preflight.yml
@@ -91,7 +91,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    chrony_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/superq/chrony_exporter/releases/latest', headers=_github_api_headers,
+    chrony_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _chrony_exporter_repo }}/releases/latest', headers=_github_api_headers,
                             split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: chrony_exporter_version is version('0.0.0', '>=')

--- a/roles/mysqld_exporter/tasks/preflight.yml
+++ b/roles/mysqld_exporter/tasks/preflight.yml
@@ -91,7 +91,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    mysqld_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/prometheus/mysqld_exporter/releases/latest', headers=_github_api_headers,
+    mysqld_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _mysqld_exporter_repo }}/releases/latest', headers=_github_api_headers,
                               split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: mysqld_exporter_version is version('0.0.0', '>=')

--- a/roles/node_exporter/tasks/preflight.yml
+++ b/roles/node_exporter/tasks/preflight.yml
@@ -91,7 +91,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    node_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/prometheus/node_exporter/releases/latest', headers=_github_api_headers,
+    node_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _node_exporter_repo }}/releases/latest', headers=_github_api_headers,
                             split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: node_exporter_version is version('0.0.0', '>=')

--- a/roles/prometheus/tasks/preflight.yml
+++ b/roles/prometheus/tasks/preflight.yml
@@ -91,7 +91,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    prometheus_version: "{{ (lookup('url', 'https://api.github.com/repos/prometheus/prometheus/releases/latest', headers=_github_api_headers,
+    prometheus_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _prometheus_repo}}/releases/latest', headers=_github_api_headers,
                          split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: prometheus_version is version('0.0.0', '>=')

--- a/roles/pushgateway/tasks/preflight.yml
+++ b/roles/pushgateway/tasks/preflight.yml
@@ -85,7 +85,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    pushgateway_version: "{{ (lookup('url', 'https://api.github.com/repos/prometheus/pushgateway/releases/latest', headers=_github_api_headers,
+    pushgateway_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _pushgateway_repo }}/releases/latest', headers=_github_api_headers,
                             split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: pushgateway_version is version('0.0.0', '>=')

--- a/roles/smartctl_exporter/tasks/preflight.yml
+++ b/roles/smartctl_exporter/tasks/preflight.yml
@@ -80,7 +80,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    smartctl_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/prometheus-community/smartctl_exporter/releases/latest', headers=_github_api_headers,
+    smartctl_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _smartctl_exporter_repo }}/releases/latest', headers=_github_api_headers,
                             split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: smartctl_exporter_version is version('0.0.0', '>=')

--- a/roles/snmp_exporter/tasks/preflight.yml
+++ b/roles/snmp_exporter/tasks/preflight.yml
@@ -23,7 +23,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    snmp_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/prometheus/snmp_exporter/releases/latest', headers=_github_api_headers,
+    snmp_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _snmp_exporter_repo }}/releases/latest', headers=_github_api_headers,
                             split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: snmp_exporter_version is version('0.0.0', '>=')

--- a/roles/systemd_exporter/tasks/preflight.yml
+++ b/roles/systemd_exporter/tasks/preflight.yml
@@ -98,7 +98,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    systemd_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/prometheus-community/systemd_exporter/releases/latest',
+    systemd_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _systemd_exporter_repo }}/releases/latest',
                                headers=_github_api_headers, split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: systemd_exporter_version is version('0.0.0', '>=')


### PR DESCRIPTION
Use the per-role repo var consistently in the preflight GitHub API URLs.