### PR TITLE
fix(mysqld_exporter): Change condition for mysqld_exporter_host check

### DIFF
--- a/roles/mysqld_exporter/templates/my_cnf.j2
+++ b/roles/mysqld_exporter/templates/my_cnf.j2
@@ -2,7 +2,7 @@
 [client]
 user={{ mysqld_exporter_username }}
 password={{ mysqld_exporter_password }}
-{% if mysqld_exporter_host is defined %}
+{% if mysqld_exporter_host %}
 host={{ mysqld_exporter_host }}
 port={{ mysqld_exporter_port }}
 {% elif mysqld_exporter_socket is defined %}


### PR DESCRIPTION
Modify the condition for `mysqld_exporter_host` in the mysqld_exporter my_cnf.j2 template to address an issue where `mysqld_exporter_host: null` in roles/defaults/main.yml was not being handled correctly. The updated condition ensures the host setting logic operates properly even when `mysqld_exporter_host` is set to null.

I also think a useful approach would be to simply remove mysqld_exporter_host[port] from defaults/main.yml and not change the template condition. I would appreciate your comments on this.