### PR TITLE
fix: Don't reload services when restarting

### DIFF
--- a/roles/alertmanager/handlers/main.yml
+++ b/roles/alertmanager/handlers/main.yml
@@ -6,6 +6,7 @@
     daemon_reload: true
     name: alertmanager
     state: restarted
+  register: alertmanager_restarted
 
 - name: Reload alertmanager
   listen: "reload alertmanager"
@@ -13,3 +14,4 @@
   ansible.builtin.systemd:
     name: alertmanager
     state: reloaded
+  when: alertmanager_restarted is not defined

--- a/roles/blackbox_exporter/handlers/main.yml
+++ b/roles/blackbox_exporter/handlers/main.yml
@@ -6,6 +6,7 @@
     daemon_reload: true
     name: blackbox_exporter
     state: restarted
+  register: blackbox_exporter_restarted
 
 - name: Reload blackbox_exporter
   listen: "reload blackbox_exporter"
@@ -13,3 +14,4 @@
   ansible.builtin.systemd:
     name: blackbox_exporter
     state: reloaded
+  when: blackbox_exporter_restarted is not defined

--- a/roles/prometheus/handlers/main.yml
+++ b/roles/prometheus/handlers/main.yml
@@ -6,6 +6,7 @@
     daemon_reload: true
     name: prometheus
     state: restarted
+  register: prometheus_restarted
 
 - name: Reload prometheus
   listen: "reload prometheus"
@@ -13,3 +14,4 @@
   ansible.builtin.systemd:
     name: prometheus
     state: reloaded
+  when: prometheus_restarted is not defined

--- a/roles/snmp_exporter/handlers/main.yml
+++ b/roles/snmp_exporter/handlers/main.yml
@@ -1,12 +1,4 @@
 ---
-- name: Reload snmp_exporter
-  listen: "reload snmp_exporter"
-  become: true
-  ansible.builtin.systemd:
-    daemon_reload: true
-    name: snmp_exporter
-    state: reloaded
-
 - name: Restart snmp_exporter
   listen: "restart snmp_exporter"
   become: true
@@ -14,3 +6,13 @@
     daemon_reload: true
     name: snmp_exporter
     state: restarted
+  register: snmp_exporter_restarted
+
+- name: Reload snmp_exporter
+  listen: "reload snmp_exporter"
+  become: true
+  ansible.builtin.systemd:
+    daemon_reload: true
+    name: snmp_exporter
+    state: reloaded
+  when: snmp_exporter_restarted is not defined


### PR DESCRIPTION
Avoid triggering a reload of various role services when a restart is needed. This avoids the race between restart and reload.