### PR TITLE
enhancement: Add systemd socket listener activation

### DIFF
--- a/roles/node_exporter/defaults/main.yml
+++ b/roles/node_exporter/defaults/main.yml
@@ -6,7 +6,8 @@ node_exporter_binary_url: "https://github.com/{{ _node_exporter_repo }}/releases
 node_exporter_checksums_url: "https://github.com/{{ _node_exporter_repo }}/releases/download/v{{ node_exporter_version }}/sha256sums.txt"
 node_exporter_skip_install: false
 
-node_exporter_web_listen_address: "0.0.0.0:9100"
+node_exporter_web_listen_port: 9100
+node_exporter_web_listen_address: "0.0.0.0:{{ node_exporter_web_listen_port }}"
 node_exporter_web_telemetry_path: "/metrics"
 
 node_exporter_textfile_dir: "/var/lib/node_exporter"

--- a/roles/node_exporter/tasks/configure.yml
+++ b/roles/node_exporter/tasks/configure.yml
@@ -8,6 +8,15 @@
     mode: 0644
   notify: restart node_exporter
 
+- name: Copy the node_exporter systemd socket file
+  ansible.builtin.template:
+    src: node_exporter.socket.j2
+    dest: /usr/lib/systemd/system/node_exporter.socket
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart node_exporter
+
 - name: Create node_exporter config directory
   ansible.builtin.file:
     path: "/etc/node_exporter"

--- a/roles/node_exporter/templates/node_exporter.service.j2
+++ b/roles/node_exporter/templates/node_exporter.service.j2
@@ -3,12 +3,13 @@
 [Unit]
 Description=Prometheus Node Exporter
 After=network-online.target
+Requires=node_exporter.socket
 
 [Service]
 Type=simple
 User={{ node_exporter_system_user }}
 Group={{ node_exporter_system_group }}
-ExecStart={{ node_exporter_binary_install_dir }}/node_exporter \
+ExecStart={{ node_exporter_binary_install_dir }}/node_exporter --web.systemd-socket \
 {% for collector in node_exporter_enabled_collectors -%}
 {%   if not collector is mapping %}
     '--collector.{{ collector }}' \

--- a/roles/node_exporter/templates/node_exporter.socket.j2
+++ b/roles/node_exporter/templates/node_exporter.socket.j2
@@ -1,0 +1,8 @@
+[Unit]
+Description=Node Exporter
+
+[Socket]
+ListenStream={{ node_exporter_web_listen_port }}
+
+[Install]
+WantedBy=socket.target


### PR DESCRIPTION
This allows systemd to open the listening port and enable the exporter. it can maintain the port open even if the exporter is not running. it should also open the port at boot before a process has an opportunity of taking it. in addition, it will queue TCP requests in case the exporter goes down, attempt to start the exporter, and then forward the requests to the exporter. 