### PR TITLE
patch: Configurable Prometheus system user and group vars

### DIFF
--- a/roles/prometheus/defaults/main.yml
+++ b/roles/prometheus/defaults/main.yml
@@ -227,4 +227,7 @@ prometheus_alert_rules:  # noqa yaml[line-length]  # noqa line-length
       severity: warning
 # yamllint enable rule:line-length
 
+prometheus_system_group: 'prometheus'
+prometheus_system_user: "{{ prometheus_system_group }}"
+
 prometheus_stop_timeout: '600s'

--- a/roles/prometheus/meta/argument_specs.yml
+++ b/roles/prometheus/meta/argument_specs.yml
@@ -150,6 +150,16 @@ argument_specs:
         default:
           - "prometheus/targets/*.yml"
           - "prometheus/targets/*.json"
+      prometheus_system_group:
+        description:
+          - "System group for Prometheus."
+        type: "str"
+        default: "prometheus"
+      prometheus_system_user:
+        description:
+          - "System user for Prometheus."
+        type: "str"
+        default: "prometheus"
       prometheus_stop_timeout:
         description:
           - "How long to wait for Prometheus to shutdown. This is passed as a systemd TimeoutStopSec time spec."

--- a/roles/prometheus/tasks/configure.yml
+++ b/roles/prometheus/tasks/configure.yml
@@ -4,7 +4,7 @@
     src: "alert.rules.j2"
     dest: "{{ prometheus_config_dir }}/rules/ansible_managed.rules"
     owner: root
-    group: prometheus
+    group: "{{ prometheus_system_group }}"
     mode: 0640
     validate: "{{ _prometheus_binary_install_dir }}/promtool check rules %s"
   when:
@@ -18,7 +18,7 @@
     src: "{{ item }}"
     dest: "{{ prometheus_config_dir }}/rules/"
     owner: root
-    group: prometheus
+    group: "{{ prometheus_system_group }}"
     mode: 0640
     validate: "{{ _prometheus_binary_install_dir }}/promtool check rules %s"
   with_fileglob: "{{ prometheus_alert_rules_files }}"
@@ -33,7 +33,7 @@
     dest: "{{ prometheus_config_dir }}/prometheus.yml"
     force: true
     owner: root
-    group: prometheus
+    group: "{{ prometheus_system_group }}"
     mode: 0640
     validate: "{{ _prometheus_binary_install_dir }}/promtool check config %s"
   no_log: "{{ false if (lookup('env', 'CI')) or (lookup('env', 'MOLECULE_PROVISIONER_NAME')) else true }}"
@@ -46,7 +46,7 @@
     dest: "{{ prometheus_config_dir }}/web.yml"
     force: true
     owner: root
-    group: prometheus
+    group: "{{ prometheus_system_group }}"
     mode: 0640
 
 - name: Configure prometheus static targets
@@ -56,7 +56,7 @@
     dest: "{{ prometheus_config_dir }}/file_sd/{{ item.key }}.yml"
     force: true
     owner: root
-    group: prometheus
+    group: "{{ prometheus_system_group }}"
     mode: 0640
   with_dict: "{{ prometheus_targets }}"
   when: prometheus_targets != {}
@@ -67,6 +67,6 @@
     dest: "{{ prometheus_config_dir }}/file_sd/"
     force: true
     owner: root
-    group: prometheus
+    group: "{{ prometheus_system_group }}"
     mode: 0640
   with_fileglob: "{{ prometheus_static_targets_files }}"

--- a/roles/prometheus/tasks/install.yml
+++ b/roles/prometheus/tasks/install.yml
@@ -1,16 +1,16 @@
 ---
 - name: Create prometheus system group
   ansible.builtin.group:
-    name: prometheus
+    name: "{{ prometheus_system_group }}"
     system: true
     state: present
 
 - name: Create prometheus system user
   ansible.builtin.user:
-    name: prometheus
+    name: "{{ prometheus_system_user }}"
     system: true
     shell: "/usr/sbin/nologin"
-    group: prometheus
+    group: "{{ prometheus_system_group }}"
     createhome: false
     home: "{{ prometheus_db_dir }}"
 
@@ -18,8 +18,8 @@
   ansible.builtin.file:
     path: "{{ prometheus_db_dir }}"
     state: directory
-    owner: prometheus
-    group: prometheus
+    owner: "{{ prometheus_system_user }}"
+    group: "{{ prometheus_system_group }}"
     mode: 0755
 
 - name: Create prometheus configuration directories
@@ -27,7 +27,7 @@
     path: "{{ item }}"
     state: directory
     owner: root
-    group: prometheus
+    group: "{{ prometheus_system_group }}"
     mode: 0770
   with_items:
     - "{{ prometheus_config_dir }}"

--- a/roles/prometheus/templates/prometheus.service.j2
+++ b/roles/prometheus/templates/prometheus.service.j2
@@ -9,8 +9,8 @@ After=local-fs.target
 [Service]
 Type=simple
 Environment="GOMAXPROCS={{ ansible_processor_vcpus|default(ansible_processor_count) }}"
-User=prometheus
-Group=prometheus
+User={{ prometheus_system_user }}
+Group={{ prometheus_system_group }}
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStart={{ _prometheus_binary_install_dir }}/prometheus \
 {% if not prometheus_agent_mode %}


### PR DESCRIPTION
The use case is that when we want to deploy multiple Prometheus instances on the same host with different data directories. The current role have system user and group _hardcoded_ in the tasks and more over the Prometheus system user's home directory is set to Prometheus data directory.

When two different instances with two different data directories are deployed on the same instance, this will cause failures as we cannot change user's home directory while it is in use.

This PR simply adds the vars `prometheus_system_{user,group}` and set to `prometheus` and replace all instances of Prometheus user and group with variable references.