### PR TITLE
skip_changelog(ci): gitlab.com support for version updater

### DIFF
--- a/.github/scripts/discover_role_repos.sh
+++ b/.github/scripts/discover_role_repos.sh
@@ -5,7 +5,7 @@
 result=$(
   for defaults_file in roles/*/vars/main.yml ; do
     role="$(echo "${defaults_file}" | cut -f2 -d'/')"
-    yq eval "[{\"repo\": ._${role}_repo, \"role\": \"${role}\"}]" "${defaults_file}"
+    yq eval "[{\"repo\": ._${role}_repo, \"role\": \"${role}\", \"type\": ._${role}_repo_type // \"github\"}]" "${defaults_file}"
   done | yq -o json -I=0
 )
 

--- a/.github/scripts/version_updater.sh
+++ b/.github/scripts/version_updater.sh
@@ -68,10 +68,11 @@ if [[ -z "${role}" ]]; then
 fi
 
 # Get latest version.
-if [[ ${type} == "github" ]]
+if [[ "${type}" == "github" ]]
 then
   version="$(github_api "repos/${source_repo}/releases/latest" | jq '.tag_name' | tr -d '"v')"
-elif [[ ${type} == "gitlab" ]]
+elif [[ "${type}" == "gitlab" ]]
+then
   version="$(curl https://gitlab.com/api/v4/projects/${source_repo}/releases|jq '.[0].tag_name'| tr -d '"v')"
 else
   echo_red 'Unknown source type. Terminating.'

--- a/.github/scripts/version_updater.sh
+++ b/.github/scripts/version_updater.sh
@@ -73,7 +73,7 @@ then
   version="$(github_api "repos/${source_repo}/releases/latest" | jq '.tag_name' | tr -d '"v')"
 elif [[ "${type}" == "gitlab" ]]
 then
-  version="$(curl https://gitlab.com/api/v4/projects/${source_repo}/releases|jq '.[0].tag_name'| tr -d '"v')"
+  version="$(curl --retry 5 --silent --fail "https://gitlab.com/api/v4/projects/${source_repo}/releases"|jq '.[0].tag_name'| tr -d '"v')"
 else
   echo_red 'Unknown source type. Terminating.'
   exit 128

--- a/.github/scripts/version_updater.sh
+++ b/.github/scripts/version_updater.sh
@@ -13,6 +13,7 @@ fi
 
 source_repo="$1"
 role="$2"
+type="$3"
 
 color_red='\e[31m'
 color_green='\e[32m'
@@ -67,7 +68,15 @@ if [[ -z "${role}" ]]; then
 fi
 
 # Get latest version.
-version="$(github_api "repos/${source_repo}/releases/latest" | jq '.tag_name' | tr -d '"v')"
+if [[ ${type} == "github" ]]
+then
+  version="$(github_api "repos/${source_repo}/releases/latest" | jq '.tag_name' | tr -d '"v')"
+elif [[ ${type} == "gitlab" ]]
+  version="$(curl https://gitlab.com/api/v4/projects/${source_repo}/releases|jq '.[0].tag_name'| tr -d '"v')"
+else
+  echo_red 'Unknown source type. Terminating.'
+  exit 128
+fi
 echo_green "New ${source_repo} version is: ${version}"
 
 # Download destination repository

--- a/.github/scripts/version_updater.sh
+++ b/.github/scripts/version_updater.sh
@@ -75,16 +75,18 @@ if [[ -z "${role}" ]]; then
 fi
 
 # Get latest version.
-if [[ "${type}" == "github" ]]
-then
-  version="$(github_api "repos/${source_repo}/releases/latest" | jq '.tag_name' | tr -d '"v')"
-elif [[ "${type}" == "gitlab" ]]
-then
-  version="$(gitlab_api "projects/${source_repo}/releases" | jq '.[0].tag_name' | tr -d '"v')"
-else
-  echo_red 'Unknown source type. Terminating.'
-  exit 128
-fi
+case "${type}" in
+  github)
+    version="$(github_api "repos/${source_repo}/releases/latest" | jq '.tag_name' | tr -d '"v')"
+    ;;
+  gitlab)
+    version="$(gitlab_api "projects/${source_repo}/releases" | jq '.[0].tag_name' | tr -d '"v')"
+    ;;
+  *)
+    echo_red 'Unknown source type. Terminating.'
+    exit 128
+    ;;
+esac
 echo_green "New ${source_repo} version is: ${version}"
 
 # Download destination repository

--- a/.github/scripts/version_updater.sh
+++ b/.github/scripts/version_updater.sh
@@ -39,6 +39,13 @@ github_api() {
   curl --retry 5 --silent --fail -u "${GIT_USER}:${GITHUB_TOKEN}" "${url}" "$@"
 }
 
+gitlab_api() {
+  local url
+  url="https://gitlab.com/api/v4/${1}"
+  shift 1
+  curl --retry 5 --silent --fail "${url}" "$@"
+}
+
 post_pull_request() {
   local pr_title="$1"
   local default_branch="$2"
@@ -73,7 +80,7 @@ then
   version="$(github_api "repos/${source_repo}/releases/latest" | jq '.tag_name' | tr -d '"v')"
 elif [[ "${type}" == "gitlab" ]]
 then
-  version="$(curl --retry 5 --silent --fail "https://gitlab.com/api/v4/projects/${source_repo}/releases"|jq '.[0].tag_name'| tr -d '"v')"
+  version="$(gitlab_api "projects/${source_repo}/releases" | jq '.[0].tag_name' | tr -d '"v')"
 else
   echo_red 'Unknown source type. Terminating.'
   exit 128

--- a/.github/workflows/version_bumper.yml
+++ b/.github/workflows/version_bumper.yml
@@ -37,4 +37,4 @@ jobs:
         include: ${{ fromJson(needs.discover-role-repos.outputs.role-repos) }}
     steps:
       - uses: actions/checkout@v3
-      - run: ./.github/scripts/version_updater.sh ${{ matrix.repo }} ${{ matrix.role }}
+      - run: ./.github/scripts/version_updater.sh ${{ matrix.repo }} ${{ matrix.role }} ${{ matrix.type }}

--- a/roles/fail2ban_exporter/tasks/preflight.yml
+++ b/roles/fail2ban_exporter/tasks/preflight.yml
@@ -55,7 +55,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    fail2ban_exporter_version: "{{ (lookup('url', 'https://gitlab.com/api/v4/projects/{{ _gitlab_projectid }}/releases',
+    fail2ban_exporter_version: "{{ (lookup('url', 'https://gitlab.com/api/v4/projects/{{ _fail2ban_exporter_repo }}/releases',
                             split_lines=False) | from_json)[0].get('tag_name') | replace('v', '') }}"
   run_once: true
   until: fail2ban_exporter_version is version('0.0.0', '>=')

--- a/roles/fail2ban_exporter/vars/main.yml
+++ b/roles/fail2ban_exporter/vars/main.yml
@@ -7,4 +7,5 @@ go_arch_map:
   armv6l: 'armv6'
 
 go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
-_gitlab_projectid: 24199687
+_fail2ban_exporter_repo: 24199687
+_fail2ban_exporter_repo_type: gitlab


### PR DESCRIPTION
Support gitlab.com projects for `version_updater.sh`
@SuperQ as we discussed here #294 
Please, check this code, because I don't know how to test it myself completely.
My main idea was to keep code structure unchanged so much as possible.