### PR TITLE
fix: change monogdb exporter collector check in service

### DIFF
--- a/roles/mongodb_exporter/defaults/main.yml
+++ b/roles/mongodb_exporter/defaults/main.yml
@@ -11,6 +11,7 @@ mongodb_exporter_web_listen_address: "0.0.0.0:9216"
 mongodb_exporter_web_telemetry_path: "/metrics"
 
 mongodb_exporter_uri: "mongodb://127.0.0.1:27017/admin?ssl=false"
+# specify a list of collectors or "all"
 mongodb_exporter_collectors: []
 mongodb_exporter_collstats_colls: []
 mongodb_exporter_indexstats_colls: []

--- a/roles/mongodb_exporter/templates/mongodb_exporter.service.j2
+++ b/roles/mongodb_exporter/templates/mongodb_exporter.service.j2
@@ -12,7 +12,7 @@ User={{ mongodb_exporter_system_user }}
 Group={{ mongodb_exporter_system_group }}
 
 ExecStart={{ mongodb_exporter_binary_install_dir }}/mongodb_exporter \
-{% if mongodb_exporter_collectors is iterable %}
+{% if mongodb_exporter_collectors | type_debug == "list" %}
 {% for collector in mongodb_exporter_collectors -%}
     --collector.{{ collector }} \
 {% endfor %}


### PR DESCRIPTION
The collectors section within in the systemd service file checks if mongodb_exporter_collectors is iterable.
Since string is iterable the elif block does not trigger.

It results in:
```
ExecStart=/usr/local/bin/mongodb_exporter \
--collector.a \
--collector.l \
--collector.l \
     --web.listen-address=0.0.0.0:9216 \
```

I have change the check to not look for `iterable` but explicit check for `list`