### PR TITLE
fix(ipmi_exporter): add option to impi_exporter service to allow tmp file creation

### DIFF
--- a/roles/ipmi_exporter/templates/ipmi_exporter.service.j2
+++ b/roles/ipmi_exporter/templates/ipmi_exporter.service.j2
@@ -30,6 +30,7 @@ ProtectSystem=strict
 ProtectControlGroups=true
 ProtectKernelModules=true
 ProtectKernelTunables=yes
+PrivateTmp=true
 {% else %}
 ProtectSystem=full
 {% endif %}


### PR DESCRIPTION
With the config before when systemd was above version 231 it was not allowed to create tmp files and with this change it now has the permissions to write tmp files.


Fixes #286 