### PR TITLE
bug: no ability to expilicitly set no direct connect and no global connection pool

### DIFF
--- a/roles/mongodb_exporter/templates/mongodb_exporter.service.j2
+++ b/roles/mongodb_exporter/templates/mongodb_exporter.service.j2
@@ -39,9 +39,13 @@ ExecStart={{ mongodb_exporter_binary_install_dir }}/mongodb_exporter \
 {% endif -%}
 {% if mongodb_exporter_direct_connect -%}
     --mongodb.direct-connect \
+{% else -%}
+    --no-mongodb.direct-connect \
 {% endif -%}
 {% if mongodb_exporter_global_conn_pool -%}
     --mongodb.global-conn-pool \
+{% else -%}
+    --no-mongodb.global-conn-pool \
 {% endif -%}
 {% if mongodb_exporter_metrics_overridedescendingindex -%}
     --metrics.overridedescendingindex \


### PR DESCRIPTION
According to cli options:
https://github.com/percona/mongodb_exporter/blob/main/REFERENCE.md

By default direct connect sets to `true`, but when `srv+` uri for mongodb is used (srv doesn not support direct connect) it's not possible to turn it off explicity, which results in error:
```
Mar 13 10:04:49 devops1 mongodb_exporter[569538]: level=info ts=2024-03-13T09:04:49.643Z caller=tls_config.go:274 msg="Listening on" address=[::]:9216
Mar 13 10:04:49 devops1 mongodb_exporter[569538]: level=info ts=2024-03-13T09:04:49.643Z caller=tls_config.go:277 msg="TLS is disabled." http2=false address=[::]:9216
Mar 13 10:04:49 devops1 mongodb_exporter[569538]: time="2024-03-13T10:04:49+01:00" level=error msg="Cannot connect to MongoDB: invalid MongoDB options: a direct connection cannot be made if multiple hosts are spec>
Mar 13 10:09:58 devops1 systemd[1]: Stopping Prometheus MongoDB Exporter...
```