### PR TITLE
enhancement: Add ability to disable exporter metrics itself

### DIFF
--- a/roles/node_exporter/defaults/main.yml
+++ b/roles/node_exporter/defaults/main.yml
@@ -6,6 +6,7 @@ node_exporter_binary_url: "https://github.com/{{ _node_exporter_repo }}/releases
 node_exporter_checksums_url: "https://github.com/{{ _node_exporter_repo }}/releases/download/v{{ node_exporter_version }}/sha256sums.txt"
 node_exporter_skip_install: false
 
+node_exporter_web_disable_exporter_metrics: false
 node_exporter_web_listen_address: "0.0.0.0:9100"
 node_exporter_web_telemetry_path: "/metrics"
 

--- a/roles/node_exporter/meta/argument_specs.yml
+++ b/roles/node_exporter/meta/argument_specs.yml
@@ -26,6 +26,10 @@ argument_specs:
       node_exporter_checksums_url:
         description: "URL of the node exporter checksums file"
         default: "https://github.com/{{ _node_exporter_repo }}/releases/download/v{{ node_exporter_version }}/sha256sums.txt"
+      node_exporter_web_disable_exporter_metrics:
+        description: "Exclude metrics about the exporter itself (promhttp_*, process_*, go_*)."
+        type: bool
+        default: false
       node_exporter_web_listen_address:
         description: "Address on which node exporter will listen"
         default: "0.0.0.0:9100"

--- a/roles/node_exporter/templates/node_exporter.service.j2
+++ b/roles/node_exporter/templates/node_exporter.service.j2
@@ -30,6 +30,9 @@ ExecStart={{ node_exporter_binary_install_dir }}/node_exporter \
     '--web.config=/etc/node_exporter/config.yaml' \
     {% endif %}
 {% endif %}
+{% if node_exporter_web_disable_exporter_metrics %}
+    '--web.disable-exporter-metrics' \
+{% endif %}
 {% if node_exporter_version is version('1.5.0', '>=') and
       node_exporter_web_listen_address is iterable and
       node_exporter_web_listen_address is not mapping and


### PR DESCRIPTION
Add ability to disable exporter metrics itself which is a long-lasting feature of node_exporter ([source code](https://github.com/prometheus/node_exporter/blame/3accd4cf8286e69d70516abdced6bf186274322a/node_exporter.go#L164)):
```bash
$ docker run -it quay.io/prometheus/node-exporter:latest --help | grep 'web.disable' -A1
      --[no-]web.disable-exporter-metrics  
                                 Exclude metrics about the exporter itself (promhttp_*, process_*, go_*).
```