### PR TITLE
skip_changelog: satisfy cncf license scanner

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -1,8 +1,4 @@
 ---
-# Copyright (c) Ansible Project
-# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
-# SPDX-License-Identifier: GPL-3.0-or-later
-
 name: Collection Docs
 concurrency:
   group: docs-pr-${{ github.head_ref }}

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -1,8 +1,4 @@
 ---
-# Copyright (c) Ansible Project
-# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
-# SPDX-License-Identifier: GPL-3.0-or-later
-
 name: Collection Docs
 concurrency:
   group: docs-push-${{ github.sha }}


### PR DESCRIPTION
Removes GPL headers as requested: https://github.com/prometheus-community/ansible/pull/69#pullrequestreview-1874957858

It should be safe to remove the headers as the samples that these workflows are based on don't have the license headers.
https://github.com/ansible-community/github-docs-build/blob/c87c4e381fe8ef464e9d0318043ca1284af66b01/samples/pr-build-and-comment.yml
https://github.com/ansible-community/github-docs-build/blob/c87c4e381fe8ef464e9d0318043ca1284af66b01/samples/push-with-build.yml