### PR TITLE
enhancement(node_exporter): add vrf var to node_exporter

### DIFF
--- a/roles/node_exporter/defaults/main.yml
+++ b/roles/node_exporter/defaults/main.yml
@@ -28,6 +28,8 @@ node_exporter_enabled_collectors:
 
 node_exporter_disabled_collectors: []
 
+node_exporter_vrf: ""
+
 node_exporter_binary_install_dir: "/usr/local/bin"
 node_exporter_system_group: "node-exp"
 node_exporter_system_user: "{{ node_exporter_system_group }}"

--- a/roles/node_exporter/meta/argument_specs.yml
+++ b/roles/node_exporter/meta/argument_specs.yml
@@ -88,3 +88,6 @@ argument_specs:
       node_exporter_archive_path:
         description: 'Local path to stash the archive and its extraction'
         default: "/tmp"
+      node_exporter_vrf:
+        description: 'Executes the exporter in a specific vrf with `ip vrf exec`'
+        default: ""

--- a/roles/node_exporter/templates/node_exporter.service.j2
+++ b/roles/node_exporter/templates/node_exporter.service.j2
@@ -6,9 +6,13 @@ After=network-online.target
 
 [Service]
 Type=simple
+{% if node_exporter_vrf | length %}
+ExecStart=ip vrf exec {{ node_exporter_vrf }} runuser -u {{ node_exporter_system_user }} -g {{ node_exporter_system_group }} -- {{ node_exporter_binary_install_dir }}/node_exporter \
+{% else %}
 User={{ node_exporter_system_user }}
 Group={{ node_exporter_system_group }}
 ExecStart={{ node_exporter_binary_install_dir }}/node_exporter \
+{% endif %}
 {% for collector in node_exporter_enabled_collectors -%}
 {%   if not collector is mapping %}
     '--collector.{{ collector }}' \
@@ -62,7 +66,11 @@ NoNewPrivileges=yes
 
 {% if (ansible_facts.packages.systemd | first).version is version('232', '>=') %}
 ProtectSystem=strict
+{% if node_exporter_vrf | length %}
+ProtectControlGroups=false
+{% else %}
 ProtectControlGroups=true
+{% endif %}
 ProtectKernelModules=true
 ProtectKernelTunables=yes
 {% else %}


### PR DESCRIPTION
We're using node-exporter on nvidia switches running cumulus. Within these switches it's mandatory for us to use the node-exporter within a vrf provided via ifupdown2. This is not limited to our usecase but can also be used on a linux vm. 

The systemd option `ProtectControlGroups` is needed for usage of vrf. Without setting the option this error is reported:
```
Apr 23 14:57:16 test-01 node_exporter[1817356]: mkdir failed for /sys/fs/cgroup/unified/system.slice/node_exporter.service/vrf: Read-only file system
Apr 23 14:57:16 test-01 node_exporter[1817356]: Failed to setup vrf cgroup2 directory
```

Not sure if this is something you want to support. If not please feel free to close this PR. If something is missing I'm happy to amend changes. 
I wasn't sure about your test requirements, if required I'm happy to extend the molecule tests.