### PR TITLE
fix: Improve apt facts install

### DIFF
--- a/roles/alertmanager/tasks/preflight.yml
+++ b/roles/alertmanager/tasks/preflight.yml
@@ -9,6 +9,7 @@
   ansible.builtin.package:
     name: "{{ _pkg_fact_req }}"
     state: present
+    install_recommends: false
   when: (_pkg_fact_req)
   vars:
     _pkg_fact_req: "{% if (ansible_pkg_mgr == 'apt') %}\

--- a/roles/bind_exporter/tasks/preflight.yml
+++ b/roles/bind_exporter/tasks/preflight.yml
@@ -9,6 +9,7 @@
   ansible.builtin.package:
     name: "{{ _pkg_fact_req }}"
     state: present
+    install_recommends: false
   when: (_pkg_fact_req)
   vars:
     _pkg_fact_req: "{% if (ansible_pkg_mgr == 'apt') %}\

--- a/roles/blackbox_exporter/tasks/preflight.yml
+++ b/roles/blackbox_exporter/tasks/preflight.yml
@@ -9,6 +9,7 @@
   ansible.builtin.package:
     name: "{{ _pkg_fact_req }}"
     state: present
+    install_recommends: false
   when: (_pkg_fact_req)
   vars:
     _pkg_fact_req: "{% if (ansible_pkg_mgr == 'apt') %}\

--- a/roles/cadvisor/tasks/preflight.yml
+++ b/roles/cadvisor/tasks/preflight.yml
@@ -9,6 +9,7 @@
   ansible.builtin.package:
     name: "{{ _pkg_fact_req }}"
     state: present
+    install_recommends: false
   when: (_pkg_fact_req)
   vars:
     _pkg_fact_req: "{% if (ansible_pkg_mgr == 'apt') %}\

--- a/roles/chrony_exporter/tasks/preflight.yml
+++ b/roles/chrony_exporter/tasks/preflight.yml
@@ -9,6 +9,7 @@
   ansible.builtin.package:
     name: "{{ _pkg_fact_req }}"
     state: present
+    install_recommends: false
   when: (_pkg_fact_req)
   vars:
     _pkg_fact_req: "{% if (ansible_pkg_mgr == 'apt') %}\

--- a/roles/fail2ban_exporter/tasks/preflight.yml
+++ b/roles/fail2ban_exporter/tasks/preflight.yml
@@ -9,6 +9,7 @@
   ansible.builtin.package:
     name: "{{ _pkg_fact_req }}"
     state: present
+    install_recommends: false
   when: (_pkg_fact_req)
   vars:
     _pkg_fact_req: "{% if (ansible_pkg_mgr == 'apt') %}\

--- a/roles/ipmi_exporter/tasks/preflight.yml
+++ b/roles/ipmi_exporter/tasks/preflight.yml
@@ -9,6 +9,7 @@
   ansible.builtin.package:
     name: "{{ _pkg_fact_req }}"
     state: present
+    install_recommends: false
   when: (_pkg_fact_req)
   vars:
     _pkg_fact_req: "{% if (ansible_pkg_mgr == 'apt') %}\

--- a/roles/memcached_exporter/tasks/preflight.yml
+++ b/roles/memcached_exporter/tasks/preflight.yml
@@ -9,6 +9,7 @@
   ansible.builtin.package:
     name: "{{ _pkg_fact_req }}"
     state: present
+    install_recommends: false
   when: (_pkg_fact_req)
   vars:
     _pkg_fact_req: "{% if (ansible_pkg_mgr == 'apt') %}\

--- a/roles/mongodb_exporter/tasks/preflight.yml
+++ b/roles/mongodb_exporter/tasks/preflight.yml
@@ -9,6 +9,7 @@
   ansible.builtin.package:
     name: "{{ _pkg_fact_req }}"
     state: present
+    install_recommends: false
   when: (_pkg_fact_req)
   vars:
     _pkg_fact_req: "{% if (ansible_pkg_mgr == 'apt') %}\

--- a/roles/mysqld_exporter/tasks/preflight.yml
+++ b/roles/mysqld_exporter/tasks/preflight.yml
@@ -9,6 +9,7 @@
   ansible.builtin.package:
     name: "{{ _pkg_fact_req }}"
     state: present
+    install_recommends: false
   when: (_pkg_fact_req)
   vars:
     _pkg_fact_req: "{% if (ansible_pkg_mgr == 'apt') %}\

--- a/roles/nginx_exporter/tasks/preflight.yml
+++ b/roles/nginx_exporter/tasks/preflight.yml
@@ -9,6 +9,7 @@
   ansible.builtin.package:
     name: "{{ _pkg_fact_req }}"
     state: present
+    install_recommends: false
   when: (_pkg_fact_req)
   vars:
     _pkg_fact_req: "{% if (ansible_pkg_mgr == 'apt') %}\

--- a/roles/node_exporter/tasks/preflight.yml
+++ b/roles/node_exporter/tasks/preflight.yml
@@ -9,6 +9,7 @@
   ansible.builtin.package:
     name: "{{ _pkg_fact_req }}"
     state: present
+    install_recommends: false
   when: (_pkg_fact_req)
   vars:
     _pkg_fact_req: "{% if (ansible_pkg_mgr == 'apt') %}\

--- a/roles/postgres_exporter/tasks/preflight.yml
+++ b/roles/postgres_exporter/tasks/preflight.yml
@@ -9,6 +9,7 @@
   ansible.builtin.package:
     name: "{{ _pkg_fact_req }}"
     state: present
+    install_recommends: false
   when: (_pkg_fact_req)
   vars:
     _pkg_fact_req: "{% if (ansible_pkg_mgr == 'apt') %}\

--- a/roles/process_exporter/tasks/preflight.yml
+++ b/roles/process_exporter/tasks/preflight.yml
@@ -9,6 +9,7 @@
   ansible.builtin.package:
     name: "{{ _pkg_fact_req }}"
     state: present
+    install_recommends: false
   when: (_pkg_fact_req)
   vars:
     _pkg_fact_req: "{% if (ansible_pkg_mgr == 'apt') %}\

--- a/roles/prometheus/tasks/preflight.yml
+++ b/roles/prometheus/tasks/preflight.yml
@@ -9,6 +9,7 @@
   ansible.builtin.package:
     name: "{{ _pkg_fact_req }}"
     state: present
+    install_recommends: false
   when: (_pkg_fact_req)
   vars:
     _pkg_fact_req: "{% if (ansible_pkg_mgr == 'apt') %}\

--- a/roles/pushgateway/tasks/preflight.yml
+++ b/roles/pushgateway/tasks/preflight.yml
@@ -9,6 +9,7 @@
   ansible.builtin.package:
     name: "{{ _pkg_fact_req }}"
     state: present
+    install_recommends: false
   when: (_pkg_fact_req)
   vars:
     _pkg_fact_req: "{% if (ansible_pkg_mgr == 'apt') %}\

--- a/roles/redis_exporter/tasks/preflight.yml
+++ b/roles/redis_exporter/tasks/preflight.yml
@@ -9,6 +9,7 @@
   ansible.builtin.package:
     name: "{{ _pkg_fact_req }}"
     state: present
+    install_recommends: false
   when: (_pkg_fact_req)
   vars:
     _pkg_fact_req: "{% if (ansible_pkg_mgr == 'apt') %}\

--- a/roles/smartctl_exporter/tasks/preflight.yml
+++ b/roles/smartctl_exporter/tasks/preflight.yml
@@ -9,6 +9,7 @@
   ansible.builtin.package:
     name: "{{ _pkg_fact_req }}"
     state: present
+    install_recommends: false
   when: (_pkg_fact_req)
   vars:
     _pkg_fact_req: "{% if (ansible_pkg_mgr == 'apt') %}\

--- a/roles/smokeping_prober/tasks/preflight.yml
+++ b/roles/smokeping_prober/tasks/preflight.yml
@@ -9,6 +9,7 @@
   ansible.builtin.package:
     name: "{{ _pkg_fact_req }}"
     state: present
+    install_recommends: false
   when: (_pkg_fact_req)
   vars:
     _pkg_fact_req: "{% if (ansible_pkg_mgr == 'apt') %}\

--- a/roles/systemd_exporter/tasks/preflight.yml
+++ b/roles/systemd_exporter/tasks/preflight.yml
@@ -9,6 +9,7 @@
   ansible.builtin.package:
     name: "{{ _pkg_fact_req }}"
     state: present
+    install_recommends: false
   when: (_pkg_fact_req)
   vars:
     _pkg_fact_req: "{% if (ansible_pkg_mgr == 'apt') %}\


### PR DESCRIPTION
Reduce the number of packages installed by the apt package facts preflight by using the apt module and disabling recommends packages.