### PR TITLE
Fix: Update notify linting

### DIFF
--- a/roles/alertmanager/handlers/main.yml
+++ b/roles/alertmanager/handlers/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Restart alertmanager
-  listen: "restart alertmanager"
   become: true
   ansible.builtin.systemd:
     daemon_reload: true
@@ -9,7 +8,6 @@
   register: alertmanager_restarted
 
 - name: Reload alertmanager
-  listen: "reload alertmanager"
   become: true
   ansible.builtin.systemd:
     name: alertmanager

--- a/roles/alertmanager/tasks/configure.yml
+++ b/roles/alertmanager/tasks/configure.yml
@@ -18,8 +18,7 @@
     mode: 0644
     validate: "{{ _alertmanager_binary_install_dir }}/amtool check-config %s"
   no_log: "{{ false if (lookup('env', 'CI')) or (lookup('env', 'MOLECULE_PROVISIONER_NAME')) else true }}"
-  notify:
-    - restart alertmanager
+  notify: Restart alertmanager
 
 - name: Create systemd service unit
   ansible.builtin.template:
@@ -28,8 +27,7 @@
     owner: root
     group: root
     mode: 0644
-  notify:
-    - restart alertmanager
+  notify: Restart alertmanager
 
 - name: Copy alertmanager template files
   ansible.builtin.copy:
@@ -40,5 +38,4 @@
     group: alertmanager
     mode: 0644
   with_fileglob: "{{ alertmanager_template_files }}"
-  notify:
-    - restart alertmanager
+  notify: Restart alertmanager

--- a/roles/alertmanager/tasks/install.yml
+++ b/roles/alertmanager/tasks/install.yml
@@ -67,8 +67,7 @@
       with_items:
         - alertmanager
         - amtool
-      notify:
-        - restart alertmanager
+      notify: Restart alertmanager
 
 - name: Propagate locally distributed alertmanager and amtool binaries
   ansible.builtin.copy:
@@ -83,5 +82,4 @@
   when:
     - alertmanager_binary_local_dir | length > 0
     - not alertmanager_skip_install
-  notify:
-    - restart alertmanager
+  notify: Restart alertmanager

--- a/roles/bind_exporter/handlers/main.yml
+++ b/roles/bind_exporter/handlers/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Restart bind_exporter
-  listen: "restart bind_exporter"
   become: true
   ansible.builtin.systemd:
     daemon_reload: true

--- a/roles/bind_exporter/tasks/configure.yml
+++ b/roles/bind_exporter/tasks/configure.yml
@@ -6,7 +6,7 @@
     owner: root
     group: root
     mode: '0644'
-  notify: restart bind_exporter
+  notify: Restart bind_exporter
 
 - name: Create bind_exporter config directory
   ansible.builtin.file:
@@ -29,7 +29,7 @@
         owner: root
         group: '{{ bind_exporter_system_group }}'
         mode: '0640'
-      notify: restart bind_exporter
+      notify: Restart bind_exporter
 
 - name: Allow bind_exporter port in SELinux on RedHat OS family
   community.general.seport:

--- a/roles/bind_exporter/tasks/install.yml
+++ b/roles/bind_exporter/tasks/install.yml
@@ -55,7 +55,7 @@
         mode: '0755'
         owner: root
         group: root
-      notify: restart bind_exporter
+      notify: Restart bind_exporter
       when: not ansible_check_mode
 
 - name: Propagate locally distributed bind_exporter binary
@@ -68,4 +68,4 @@
   when:
     - bind_exporter_binary_local_dir | length > 0
     - not bind_exporter_skip_install
-  notify: restart bind_exporter
+  notify: Restart bind_exporter

--- a/roles/blackbox_exporter/handlers/main.yml
+++ b/roles/blackbox_exporter/handlers/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Restart blackbox_exporter
-  listen: "restart blackbox_exporter"
   become: true
   ansible.builtin.systemd:
     daemon_reload: true
@@ -9,7 +8,6 @@
   register: blackbox_exporter_restarted
 
 - name: Reload blackbox_exporter
-  listen: "reload blackbox_exporter"
   become: true
   ansible.builtin.systemd:
     name: blackbox_exporter

--- a/roles/blackbox_exporter/tasks/configure.yml
+++ b/roles/blackbox_exporter/tasks/configure.yml
@@ -6,8 +6,7 @@
     owner: root
     group: root
     mode: '0644'
-  notify:
-    - restart blackbox_exporter
+  notify: Restart blackbox_exporter
 
 - name: Create blackbox_exporter config directory
   ansible.builtin.file:
@@ -24,5 +23,4 @@
     owner: root
     group: "{{ blackbox_exporter_group }}"
     mode: '0644'
-  notify:
-    - reload blackbox_exporter
+  notify: Reload blackbox_exporter

--- a/roles/blackbox_exporter/tasks/install.yml
+++ b/roles/blackbox_exporter/tasks/install.yml
@@ -51,7 +51,7 @@
         mode: 0755
         owner: root
         group: root
-      notify: restart blackbox_exporter
+      notify: Restart blackbox_exporter
       when: not ansible_check_mode
 
 - name: Propagate locally distributed blackbox_exporter binary
@@ -64,7 +64,7 @@
   when:
     - blackbox_exporter_binary_local_dir | length > 0
     - not blackbox_exporter_skip_install
-  notify: restart blackbox_exporter
+  notify: Restart blackbox_exporter
 
 - name: Install libcap on Debian systems
   ansible.builtin.package:

--- a/roles/cadvisor/handlers/main.yml
+++ b/roles/cadvisor/handlers/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Restart cadvisor
-  listen: "restart cadvisor"
   become: true
   ansible.builtin.systemd:
     daemon_reload: true

--- a/roles/cadvisor/tasks/configure.yml
+++ b/roles/cadvisor/tasks/configure.yml
@@ -6,7 +6,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: restart cadvisor
+  notify: Restart cadvisor
 
 - name: Allow cadvisor port in SELinux on RedHat OS family
   community.general.seport:

--- a/roles/cadvisor/tasks/install.yml
+++ b/roles/cadvisor/tasks/install.yml
@@ -43,7 +43,7 @@
         mode: 0755
         owner: root
         group: root
-      notify: restart cadvisor
+      notify: Restart cadvisor
       when: not ansible_check_mode
 
 - name: Propagate locally distributed cadvisor binary
@@ -56,4 +56,4 @@
   when:
     - cadvisor_binary_local_dir | length > 0
     - not cadvisor_skip_install
-  notify: restart cadvisor
+  notify: Restart cadvisor

--- a/roles/chrony_exporter/handlers/main.yml
+++ b/roles/chrony_exporter/handlers/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Restart chrony_exporter
-  listen: "restart chrony_exporter"
   become: true
   ansible.builtin.systemd:
     daemon_reload: true

--- a/roles/chrony_exporter/tasks/configure.yml
+++ b/roles/chrony_exporter/tasks/configure.yml
@@ -6,7 +6,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: restart chrony_exporter
+  notify: Restart chrony_exporter
 
 - name: Create chrony_exporter config directory
   ansible.builtin.file:
@@ -23,7 +23,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: restart chrony_exporter
+  notify: Restart chrony_exporter
 
 - name: Allow chrony_exporter port in SELinux on RedHat OS family
   community.general.seport:

--- a/roles/chrony_exporter/tasks/install.yml
+++ b/roles/chrony_exporter/tasks/install.yml
@@ -53,7 +53,7 @@
         mode: 0755
         owner: root
         group: root
-      notify: restart chrony_exporter
+      notify: Restart chrony_exporter
       when: not ansible_check_mode
 
 - name: Propagate locally distributed chrony_exporter binary
@@ -66,4 +66,4 @@
   when:
     - chrony_exporter_binary_local_dir | length > 0
     - not chrony_exporter_skip_install
-  notify: restart chrony_exporter
+  notify: Restart chrony_exporter

--- a/roles/fail2ban_exporter/handlers/main.yml
+++ b/roles/fail2ban_exporter/handlers/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Restart fail2ban_exporter
-  listen: "restart fail2ban_exporter"
   become: true
   ansible.builtin.systemd:
     daemon_reload: true

--- a/roles/fail2ban_exporter/tasks/configure.yml
+++ b/roles/fail2ban_exporter/tasks/configure.yml
@@ -6,7 +6,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: restart fail2ban_exporter
+  notify: Restart fail2ban_exporter
 
 - name: Allow fail2ban_exporter port in SELinux on RedHat OS family
   community.general.seport:

--- a/roles/fail2ban_exporter/tasks/install.yml
+++ b/roles/fail2ban_exporter/tasks/install.yml
@@ -35,7 +35,7 @@
         mode: 0755
         owner: root
         group: root
-      notify: restart fail2ban_exporter
+      notify: Restart fail2ban_exporter
       when: not ansible_check_mode
 
 - name: Propagate locally distributed fail2ban_exporter binary
@@ -48,4 +48,4 @@
   when:
     - fail2ban_exporter_binary_local_dir | length > 0
     - not fail2ban_exporter_skip_install
-  notify: restart fail2ban_exporter
+  notify: Restart fail2ban_exporter

--- a/roles/ipmi_exporter/handlers/main.yml
+++ b/roles/ipmi_exporter/handlers/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Restart ipmi_exporter
-  listen: "restart ipmi_exporter"
   become: true
   ansible.builtin.systemd:
     daemon_reload: true

--- a/roles/ipmi_exporter/tasks/configure.yml
+++ b/roles/ipmi_exporter/tasks/configure.yml
@@ -6,7 +6,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: restart ipmi_exporter
+  notify: Restart ipmi_exporter
 
 - name: Create ipmi_exporter config directory
   ansible.builtin.file:
@@ -23,7 +23,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: restart ipmi_exporter
+  notify: Restart ipmi_exporter
 
 - name: Copy the ipmi_exporter config file
   ansible.builtin.template:
@@ -33,8 +33,7 @@
     group: "{{ ipmi_exporter_system_group }}"
     mode: 0640
   no_log: "{{ false if (lookup('env', 'CI')) or (lookup('env', 'MOLECULE_PROVISIONER_NAME')) else true }}"
-  notify:
-    - restart ipmi_exporter
+  notify: Restart ipmi_exporter
 
 - name: Allow ipmi_exporter port in SELinux on RedHat OS family
   community.general.seport:

--- a/roles/ipmi_exporter/tasks/install.yml
+++ b/roles/ipmi_exporter/tasks/install.yml
@@ -53,7 +53,7 @@
         mode: 0755
         owner: root
         group: root
-      notify: restart ipmi_exporter
+      notify: Restart ipmi_exporter
       when: not ansible_check_mode
 
 - name: Propagate locally distributed ipmi_exporter binary
@@ -66,7 +66,7 @@
   when:
     - ipmi_exporter_binary_local_dir | length > 0
     - not ipmi_exporter_skip_install
-  notify: restart ipmi_exporter
+  notify: Restart ipmi_exporter
 
 - name: Install freeipmi package
   ansible.builtin.package:

--- a/roles/memcached_exporter/handlers/main.yml
+++ b/roles/memcached_exporter/handlers/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Restart memcached_exporter
-  listen: "restart memcached_exporter"
   become: true
   ansible.builtin.systemd:
     daemon_reload: true

--- a/roles/memcached_exporter/tasks/configure.yml
+++ b/roles/memcached_exporter/tasks/configure.yml
@@ -6,7 +6,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: restart memcached_exporter
+  notify: Restart memcached_exporter
 
 - name: Create memcached_exporter config directory
   ansible.builtin.file:
@@ -23,7 +23,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: restart memcached_exporter
+  notify: Restart memcached_exporter
 
 - name: Allow memcached_exporter port in SELinux on RedHat OS family
   community.general.seport:

--- a/roles/memcached_exporter/tasks/install.yml
+++ b/roles/memcached_exporter/tasks/install.yml
@@ -53,7 +53,7 @@
         mode: 0755
         owner: root
         group: root
-      notify: restart memcached_exporter
+      notify: Restart memcached_exporter
       when: not ansible_check_mode
 
 - name: Propagate locally distributed memcached_exporter binary
@@ -66,4 +66,4 @@
   when:
     - memcached_exporter_binary_local_dir | length > 0
     - not memcached_exporter_skip_install
-  notify: restart memcached_exporter
+  notify: Restart memcached_exporter

--- a/roles/mongodb_exporter/handlers/main.yml
+++ b/roles/mongodb_exporter/handlers/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Restart mongodb_exporter
-  listen: "restart mongodb_exporter"
   become: true
   ansible.builtin.systemd:
     daemon_reload: true

--- a/roles/mongodb_exporter/tasks/configure.yml
+++ b/roles/mongodb_exporter/tasks/configure.yml
@@ -6,7 +6,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: restart mongodb_exporter
+  notify: Restart mongodb_exporter
 
 - name: Create mongodb_exporter config directory
   ansible.builtin.file:
@@ -23,7 +23,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: restart mongodb_exporter
+  notify: Restart mongodb_exporter
 
 - name: Allow mongodb_exporter port in SELinux on RedHat OS family
   community.general.seport:

--- a/roles/mongodb_exporter/tasks/install.yml
+++ b/roles/mongodb_exporter/tasks/install.yml
@@ -53,7 +53,7 @@
         mode: 0755
         owner: root
         group: root
-      notify: restart mongodb_exporter
+      notify: Restart mongodb_exporter
       when: not ansible_check_mode
 
 - name: Propagate locally distributed mongodb_exporter binary
@@ -66,4 +66,4 @@
   when:
     - mongodb_exporter_binary_local_dir | length > 0
     - not mongodb_exporter_skip_install
-  notify: restart mongodb_exporter
+  notify: Restart mongodb_exporter

--- a/roles/mysqld_exporter/handlers/main.yml
+++ b/roles/mysqld_exporter/handlers/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Restart mysqld_exporter
-  listen: "restart mysqld_exporter"
   become: true
   ansible.builtin.systemd:
     daemon_reload: true

--- a/roles/mysqld_exporter/tasks/configure.yml
+++ b/roles/mysqld_exporter/tasks/configure.yml
@@ -6,7 +6,7 @@
     owner: root
     group: root
     mode: '0644'
-  notify: restart mysqld_exporter
+  notify: Restart mysqld_exporter
 
 - name: Create mysqld_exporter config directory
   ansible.builtin.file:
@@ -24,7 +24,7 @@
     group: '{{ mysqld_exporter_system_group }}'
     mode: '0640'
   no_log: "{{ false if (lookup('env', 'CI')) or (lookup('env', 'MOLECULE_PROVISIONER_NAME')) else true }}"
-  notify: restart mysqld_exporter
+  notify: Restart mysqld_exporter
 
 - name: Configure mysqld_exporter web config
   when:
@@ -39,7 +39,7 @@
         owner: root
         group: '{{ mysqld_exporter_system_group }}'
         mode: '0640'
-      notify: restart mysqld_exporter
+      notify: Restart mysqld_exporter
 
 - name: Allow mysqld_exporter port in SELinux on RedHat OS family
   community.general.seport:

--- a/roles/mysqld_exporter/tasks/install.yml
+++ b/roles/mysqld_exporter/tasks/install.yml
@@ -55,7 +55,7 @@
         mode: '0755'
         owner: root
         group: root
-      notify: restart mysqld_exporter
+      notify: Restart mysqld_exporter
       when: not ansible_check_mode
 
 - name: Propagate locally distributed mysqld_exporter binary
@@ -68,4 +68,4 @@
   when:
     - mysqld_exporter_binary_local_dir | length > 0
     - not mysqld_exporter_skip_install
-  notify: restart mysqld_exporter
+  notify: Restart mysqld_exporter

--- a/roles/nginx_exporter/handlers/main.yml
+++ b/roles/nginx_exporter/handlers/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Restart nginx_exporter
-  listen: "restart nginx_exporter"
   become: true
   ansible.builtin.systemd:
     daemon_reload: true

--- a/roles/nginx_exporter/tasks/configure.yml
+++ b/roles/nginx_exporter/tasks/configure.yml
@@ -6,7 +6,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: restart nginx_exporter
+  notify: Restart nginx_exporter
 
 - name: Create nginx_exporter config directory
   ansible.builtin.file:
@@ -23,7 +23,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: restart nginx_exporter
+  notify: Restart nginx_exporter
 
 - name: Allow nginx_exporter port in SELinux on RedHat OS family
   community.general.seport:

--- a/roles/nginx_exporter/tasks/install.yml
+++ b/roles/nginx_exporter/tasks/install.yml
@@ -53,7 +53,7 @@
         mode: 0755
         owner: root
         group: root
-      notify: restart nginx_exporter
+      notify: Restart nginx_exporter
       when: not ansible_check_mode
 
 - name: Propagate locally distributed nginx_exporter binary
@@ -66,4 +66,4 @@
   when:
     - nginx_exporter_binary_local_dir | length > 0
     - not nginx_exporter_skip_install
-  notify: restart nginx_exporter
+  notify: Restart nginx_exporter

--- a/roles/node_exporter/handlers/main.yml
+++ b/roles/node_exporter/handlers/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Restart node_exporter
-  listen: "restart node_exporter"
   become: true
   ansible.builtin.systemd:
     daemon_reload: true

--- a/roles/node_exporter/tasks/configure.yml
+++ b/roles/node_exporter/tasks/configure.yml
@@ -6,7 +6,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: restart node_exporter
+  notify: Restart node_exporter
 
 - name: Create node_exporter config directory
   ansible.builtin.file:
@@ -23,7 +23,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: restart node_exporter
+  notify: Restart node_exporter
 
 - name: Create textfile collector dir
   ansible.builtin.file:

--- a/roles/node_exporter/tasks/install.yml
+++ b/roles/node_exporter/tasks/install.yml
@@ -53,7 +53,7 @@
         mode: 0755
         owner: root
         group: root
-      notify: restart node_exporter
+      notify: Restart node_exporter
       when: not ansible_check_mode
 
 - name: Propagate locally distributed node_exporter binary
@@ -66,4 +66,4 @@
   when:
     - node_exporter_binary_local_dir | length > 0
     - not node_exporter_skip_install
-  notify: restart node_exporter
+  notify: Restart node_exporter

--- a/roles/postgres_exporter/handlers/main.yml
+++ b/roles/postgres_exporter/handlers/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Restart postgres_exporter
-  listen: "restart postgres_exporter"
   become: true
   ansible.builtin.systemd:
     daemon_reload: true

--- a/roles/postgres_exporter/tasks/configure.yml
+++ b/roles/postgres_exporter/tasks/configure.yml
@@ -6,7 +6,7 @@
     owner: root
     group: root
     mode: '0644'
-  notify: restart postgres_exporter
+  notify: Restart postgres_exporter
 
 - name: Create postgres_exporter config directory
   ansible.builtin.file:
@@ -24,7 +24,7 @@
     group: '{{ postgres_exporter_system_group }}'
     mode: '0640'
   # no_log: "{{ false if (lookup('env', 'CI')) or (lookup('env', 'MOLECULE_PROVISIONER_NAME')) else true }}"
-  notify: restart postgres_exporter
+  notify: Restart postgres_exporter
 - name: Configure via URI
   when: postgres_exporter_uri | length > 0
   block:
@@ -35,7 +35,7 @@
         owner: root
         group: '{{ postgres_exporter_system_group }}'
         mode: '0640'
-      notify: restart postgres_exporter
+      notify: Restart postgres_exporter
     - name: Creating file postgres_exporter_user
       ansible.builtin.copy:
         dest: "{{ postgres_exporter_config_dir }}/postgres_exporter_user"
@@ -43,7 +43,7 @@
         owner: root
         group: '{{ postgres_exporter_system_group }}'
         mode: '0640'
-      notify: restart postgres_exporter
+      notify: Restart postgres_exporter
     - name: Creating file postgres_exporter_pass
       ansible.builtin.copy:
         dest: "{{ postgres_exporter_config_dir }}/postgres_exporter_pass"
@@ -51,7 +51,7 @@
         owner: root
         group: '{{ postgres_exporter_system_group }}'
         mode: '0640'
-      notify: restart postgres_exporter
+      notify: Restart postgres_exporter
 
 - name: Configure postgres_exporter web config
   when:
@@ -66,7 +66,7 @@
         owner: root
         group: '{{ postgres_exporter_system_group }}'
         mode: '0640'
-      notify: restart postgres_exporter
+      notify: Restart postgres_exporter
 
 - name: Allow postgres_exporter port in SELinux on RedHat OS family
   community.general.seport:

--- a/roles/postgres_exporter/tasks/install.yml
+++ b/roles/postgres_exporter/tasks/install.yml
@@ -55,7 +55,7 @@
         mode: '0755'
         owner: root
         group: root
-      notify: restart postgres_exporter
+      notify: Restart postgres_exporter
       when: not ansible_check_mode
 
 - name: Propagate locally distributed postgres_exporter binary
@@ -68,4 +68,4 @@
   when:
     - postgres_exporter_binary_local_dir | length > 0
     - not postgres_exporter_skip_install
-  notify: restart postgres_exporter
+  notify: Restart postgres_exporter

--- a/roles/process_exporter/handlers/main.yml
+++ b/roles/process_exporter/handlers/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Restart process_exporter
-  listen: "restart process_exporter"
   become: true
   ansible.builtin.systemd:
     daemon_reload: true

--- a/roles/process_exporter/tasks/configure.yml
+++ b/roles/process_exporter/tasks/configure.yml
@@ -6,7 +6,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: restart process_exporter
+  notify: Restart process_exporter
 
 - name: Create process_exporter config directory
   ansible.builtin.file:
@@ -25,7 +25,7 @@
     mode: 0644
   when:
     - process_exporter_names != []
-  notify: restart process_exporter
+  notify: Restart process_exporter
 
 - name: Configure process_exporter web config
   ansible.builtin.template:
@@ -38,7 +38,7 @@
     ( process_exporter_tls_server_config | length > 0 ) or
     ( process_exporter_http_server_config | length > 0 ) or
     ( process_exporter_basic_auth_users | length > 0 )
-  notify: restart process_exporter
+  notify: Restart process_exporter
 
 - name: Allow process_exporter port in SELinux on RedHat OS family
   community.general.seport:

--- a/roles/process_exporter/tasks/install.yml
+++ b/roles/process_exporter/tasks/install.yml
@@ -53,7 +53,7 @@
         mode: 0755
         owner: root
         group: root
-      notify: restart process_exporter
+      notify: Restart process_exporter
       when: not ansible_check_mode
 
 - name: Propagate locally distributed process_exporter binary
@@ -66,4 +66,4 @@
   when:
     - process_exporter_binary_local_dir | length > 0
     - not process_exporter_skip_install
-  notify: restart process_exporter
+  notify: Restart process_exporter

--- a/roles/prometheus/handlers/main.yml
+++ b/roles/prometheus/handlers/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Restart prometheus
-  listen: "restart prometheus"
   become: true
   ansible.builtin.systemd:
     daemon_reload: true
@@ -9,7 +8,6 @@
   register: prometheus_restarted
 
 - name: Reload prometheus
-  listen: "reload prometheus"
   become: true
   ansible.builtin.systemd:
     name: prometheus

--- a/roles/prometheus/tasks/configure.yml
+++ b/roles/prometheus/tasks/configure.yml
@@ -10,8 +10,7 @@
   when:
     - prometheus_alert_rules != []
     - not prometheus_agent_mode
-  notify:
-    - reload prometheus
+  notify: Reload prometheus
 
 - name: Copy custom alerting rule files
   ansible.builtin.copy:
@@ -24,8 +23,7 @@
   with_fileglob: "{{ prometheus_alert_rules_files }}"
   when:
     - not prometheus_agent_mode
-  notify:
-    - reload prometheus
+  notify: Reload prometheus
 
 - name: Configure prometheus
   ansible.builtin.template:
@@ -37,8 +35,7 @@
     mode: 0640
     validate: "{{ _prometheus_binary_install_dir }}/promtool check config %s"
   no_log: "{{ false if (lookup('env', 'CI')) or (lookup('env', 'MOLECULE_PROVISIONER_NAME')) else true }}"
-  notify:
-    - reload prometheus
+  notify: Reload prometheus
 
 - name: Configure Prometheus web
   ansible.builtin.copy:

--- a/roles/prometheus/tasks/install.yml
+++ b/roles/prometheus/tasks/install.yml
@@ -74,8 +74,7 @@
       with_items:
         - prometheus
         - promtool
-      notify:
-        - restart prometheus
+      notify: Restart prometheus
 
     - name: Propagate official console templates
       ansible.builtin.copy:
@@ -87,8 +86,7 @@
       with_items:
         - console_libraries
         - consoles
-      notify:
-        - restart prometheus
+      notify: Restart prometheus
 
 - name: Propagate locally distributed prometheus and promtool binaries
   ansible.builtin.copy:
@@ -103,8 +101,7 @@
   when:
     - prometheus_binary_local_dir | length > 0
     - not prometheus_skip_install
-  notify:
-    - restart prometheus
+  notify: Restart prometheus
 
 - name: Create systemd service unit
   ansible.builtin.template:
@@ -113,8 +110,7 @@
     owner: root
     group: root
     mode: 0644
-  notify:
-    - restart prometheus
+  notify: Restart prometheus
 
 - name: Install SELinux dependencies
   ansible.builtin.package:

--- a/roles/pushgateway/handlers/main.yml
+++ b/roles/pushgateway/handlers/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Restart pushgateway
-  listen: "restart pushgateway"
   become: true
   ansible.builtin.systemd:
     daemon_reload: true

--- a/roles/pushgateway/tasks/configure.yml
+++ b/roles/pushgateway/tasks/configure.yml
@@ -6,7 +6,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: restart pushgateway
+  notify: Restart pushgateway
 
 - name: Create pushgateway config directory
   ansible.builtin.file:
@@ -23,7 +23,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: restart pushgateway
+  notify: Restart pushgateway
 
 - name: Allow pushgateway port in SELinux on RedHat OS family
   community.general.seport:

--- a/roles/pushgateway/tasks/install.yml
+++ b/roles/pushgateway/tasks/install.yml
@@ -53,7 +53,7 @@
         mode: 0755
         owner: root
         group: root
-      notify: restart pushgateway
+      notify: Restart pushgateway
       when: not ansible_check_mode
 
 - name: Propagate locally distributed pushgateway binary
@@ -66,4 +66,4 @@
   when:
     - pushgateway_binary_local_dir | length > 0
     - not pushgateway_skip_install
-  notify: restart pushgateway
+  notify: Restart pushgateway

--- a/roles/redis_exporter/handlers/main.yml
+++ b/roles/redis_exporter/handlers/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Restart redis_exporter
-  listen: "restart redis_exporter"
   become: true
   ansible.builtin.systemd:
     daemon_reload: true

--- a/roles/redis_exporter/tasks/configure.yml
+++ b/roles/redis_exporter/tasks/configure.yml
@@ -6,7 +6,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: restart redis_exporter
+  notify: Restart redis_exporter
 
 - name: Create redis_exporter config directory
   ansible.builtin.file:
@@ -23,7 +23,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: restart redis_exporter
+  notify: Restart redis_exporter
   when: redis_exporter_passwords | length > 0
 
 - name: Allow redis_exporter port in SELinux on RedHat OS family

--- a/roles/redis_exporter/tasks/install.yml
+++ b/roles/redis_exporter/tasks/install.yml
@@ -53,7 +53,7 @@
         mode: 0755
         owner: root
         group: root
-      notify: restart redis_exporter
+      notify: Restart redis_exporter
       when: not ansible_check_mode
 
 - name: Propagate locally distributed redis_exporter binary
@@ -66,4 +66,4 @@
   when:
     - redis_exporter_binary_local_dir | length > 0
     - not redis_exporter_skip_install
-  notify: restart redis_exporter
+  notify: Restart redis_exporter

--- a/roles/smartctl_exporter/handlers/main.yml
+++ b/roles/smartctl_exporter/handlers/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Restart smartctl_exporter
-  listen: "restart smartctl_exporter"
   become: true
   ansible.builtin.systemd:
     daemon_reload: true

--- a/roles/smartctl_exporter/tasks/configure.yml
+++ b/roles/smartctl_exporter/tasks/configure.yml
@@ -6,7 +6,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: restart smartctl_exporter
+  notify: Restart smartctl_exporter
 
 - name: Create smartctl_exporter config directory
   ansible.builtin.file:
@@ -23,7 +23,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: restart smartctl_exporter
+  notify: Restart smartctl_exporter
 
 - name: Allow smartctl_exporter port in SELinux on RedHat OS family
   community.general.seport:

--- a/roles/smartctl_exporter/tasks/install.yml
+++ b/roles/smartctl_exporter/tasks/install.yml
@@ -53,7 +53,7 @@
         mode: 0755
         owner: root
         group: root
-      notify: restart smartctl_exporter
+      notify: Restart smartctl_exporter
       when: not ansible_check_mode
 
 - name: Propagate locally distributed smartctl_exporter binary
@@ -66,4 +66,4 @@
   when:
     - smartctl_exporter_binary_local_dir | length > 0
     - not smartctl_exporter_skip_install
-  notify: restart smartctl_exporter
+  notify: Restart smartctl_exporter

--- a/roles/smokeping_prober/handlers/main.yml
+++ b/roles/smokeping_prober/handlers/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Restart smokeping_prober
-  listen: "restart smokeping_prober"
   become: true
   ansible.builtin.systemd:
     daemon_reload: true

--- a/roles/smokeping_prober/tasks/configure.yml
+++ b/roles/smokeping_prober/tasks/configure.yml
@@ -6,7 +6,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: restart smokeping_prober
+  notify: Restart smokeping_prober
 
 - name: Create smokeping_prober config directory
   ansible.builtin.file:
@@ -24,7 +24,7 @@
     group: root
     mode: 0644
   no_log: "{{ false if (lookup('env', 'CI')) or (lookup('env', 'MOLECULE_PROVISIONER_NAME')) else true }}"
-  notify: restart smokeping_prober
+  notify: Restart smokeping_prober
 
 - name: Configure smokeping_prober web config
   when:
@@ -39,7 +39,7 @@
         owner: root
         group: root
         mode: 0644
-      notify: restart smokeping_prober
+      notify: Restart smokeping_prober
 
 - name: Allow smokeping_prober port in SELinux on RedHat OS family
   community.general.seport:

--- a/roles/smokeping_prober/tasks/install.yml
+++ b/roles/smokeping_prober/tasks/install.yml
@@ -53,7 +53,7 @@
         mode: 0755
         owner: root
         group: root
-      notify: restart smokeping_prober
+      notify: Restart smokeping_prober
       when: not ansible_check_mode
 
 - name: Propagate locally distributed smokeping_prober binary
@@ -66,4 +66,4 @@
   when:
     - smokeping_prober_binary_local_dir | length > 0
     - not smokeping_prober_skip_install
-  notify: restart smokeping_prober
+  notify: Restart smokeping_prober

--- a/roles/snmp_exporter/handlers/main.yml
+++ b/roles/snmp_exporter/handlers/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Restart snmp_exporter
-  listen: "restart snmp_exporter"
   become: true
   ansible.builtin.systemd:
     daemon_reload: true
@@ -9,7 +8,6 @@
   register: snmp_exporter_restarted
 
 - name: Reload snmp_exporter
-  listen: "reload snmp_exporter"
   become: true
   ansible.builtin.systemd:
     daemon_reload: true

--- a/roles/snmp_exporter/tasks/configure.yml
+++ b/roles/snmp_exporter/tasks/configure.yml
@@ -6,8 +6,7 @@
     owner: root
     group: root
     mode: 0644
-  notify:
-    - restart snmp_exporter
+  notify: Restart snmp_exporter
 
 - name: Download snmp configuration file from github repository
   ansible.builtin.get_url:
@@ -21,8 +20,7 @@
   until: _download_config is success
   retries: 5
   delay: 2
-  notify:
-    - reload snmp_exporter
+  notify: Reload snmp_exporter
   when: not (snmp_exporter_config_file)
 
 - name: Copy configuration file
@@ -33,6 +31,5 @@
     group: root
     mode: 0644
   no_log: "{{ false if (lookup('env', 'CI')) or (lookup('env', 'MOLECULE_PROVISIONER_NAME')) else true }}"
-  notify:
-    - reload snmp_exporter
+  notify: Reload snmp_exporter
   when: (snmp_exporter_config_file)

--- a/roles/snmp_exporter/tasks/install.yml
+++ b/roles/snmp_exporter/tasks/install.yml
@@ -35,7 +35,7 @@
         mode: 0755
         owner: root
         group: root
-      notify: restart snmp_exporter
+      notify: Restart snmp_exporter
       when: not ansible_check_mode
 
 - name: Propagate locally distributed snmp_exporter binary
@@ -48,7 +48,7 @@
   when:
     - snmp_exporter_binary_local_dir | length > 0
     - not snmp_exporter_skip_install
-  notify: restart snmp_exporter
+  notify: Restart snmp_exporter
 
 - name: Create configuration directory
   ansible.builtin.file:

--- a/roles/systemd_exporter/handlers/main.yml
+++ b/roles/systemd_exporter/handlers/main.yml
@@ -5,4 +5,3 @@
     name: systemd_exporter
     state: restarted
   become: true
-  listen: restart systemd_exporter

--- a/roles/systemd_exporter/tasks/configure.yml
+++ b/roles/systemd_exporter/tasks/configure.yml
@@ -6,7 +6,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: restart systemd_exporter
+  notify: Restart systemd_exporter
 
 - name: Create systemd_exporter config directory
   ansible.builtin.file:
@@ -23,7 +23,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: restart systemd_exporter
+  notify: Restart systemd_exporter
 
 - name: Allow systemd_exporter port in SELinux on RedHat OS family
   community.general.seport:

--- a/roles/systemd_exporter/tasks/install.yml
+++ b/roles/systemd_exporter/tasks/install.yml
@@ -52,7 +52,7 @@
         mode: 0755
         owner: root
         group: root
-      notify: restart systemd_exporter
+      notify: Restart systemd_exporter
       when: not ansible_check_mode
 
 - name: Propagate locally distributed systemd_exporter binary
@@ -65,4 +65,4 @@
   when:
     - systemd_exporter_binary_local_dir | length > 0
     - not systemd_exporter_skip_install
-  notify: restart systemd_exporter
+  notify: Restart systemd_exporter


### PR DESCRIPTION
Latest ansible-lint now requires notifiy pass casing test.
* Remove obsolete `listen` in handlers.
* Make single notify consistent.