### PR TITLE
fix: Downgrade name[casing] to warning

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -2,5 +2,6 @@
 profile: production
 warn_list:
   - galaxy[version-incorrect]  # until collection gets bumped to 1.x.x
+  - name[casing]  # https://github.com/ansible/ansible-lint/issues/4035#issuecomment-2116272270
 skip_list:
   - var-naming[no-role-prefix]  # https://github.com/ansible/ansible-lint/pull/3422#issuecomment-1549584988


### PR DESCRIPTION
Fix linting errors by downgrading the `name[casing]` check to warning.