### PR TITLE
fix: make sure antsibull-changelog doesn't offend ansible-lint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: "Install tools"
-        run: "python -m pip install ansible-base antsibull-changelog --disable-pip-version-check"
+        run: "python -m pip install ansible-base git+https://github.com/gardar/antsibull-changelog@gardar/main --disable-pip-version-check"
 
       - name: "Calculate next version"
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: "Install tools"
-        run: "python -m pip install ansible-base git+https://github.com/gardar/antsibull-changelog@gardar/main --disable-pip-version-check"
+        run: "python -m pip install --upgrade ansible-base antsibull-changelog --disable-pip-version-check"
 
       - name: "Calculate next version"
         id: version

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -31,3 +31,5 @@ sections:
 title: Prometheus.Prometheus
 trivial_section_name: trivial
 use_fqcn: true
+changelog_nice_yaml: true
+changelog_semantic_versioning_sort: true

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -32,4 +32,4 @@ title: Prometheus.Prometheus
 trivial_section_name: trivial
 use_fqcn: true
 changelog_nice_yaml: true
-changelog_semantic_versioning_sort: true
+changelog_sort: "version_reversed"


### PR DESCRIPTION
Finally figured out why the format of `changelog.yaml` gets messed up from time to time.
I thought `antsichaut` was the culpit but it turns out that `antsibull-changelog` was responsible.

The workflow first passes the changelog to `antsibull-changelog` and then to `antsichaut`.
`antsibull-changelog` rewrites the changelog even if there is no new change but `antsichaut` skips processing it when there are no new changes.
And apparently the yaml that `antsibull-changelog` was putting out was not compatible with `ansible-lint`.

I've proposed fixes over at https://github.com/ansible-community/antsibull-changelog/pull/160 and https://github.com/ansible-community/antsibull-changelog/pull/165