### PR TITLE
docs: redirect docs page to latest release instead of docs for upcoming release

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -1,5 +1,5 @@
 ---
-name: Collection Docs
+name: Collection Docs (PR)
 concurrency:
   group: docs-pr-${{ github.head_ref }}
   cancel-in-progress: true
@@ -11,10 +11,28 @@ env:
   GHP_BASE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
 
 jobs:
+  get-tags:
+    runs-on: ubuntu-latest
+    outputs:
+      latest: ${{ steps.get-latest-tag.outputs.latest_tag }}
+    steps:
+      - name: Get the latest tag
+        id: get-latest-tag
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const latestTag = await github.rest.repos.listTags({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 1
+            });
+            core.setOutput('latest_tag', latestTag.data[0].name);
+
   build-docs:
+    name: Build Ansible Docs
+    needs: get-tags
     permissions:
       contents: read
-    name: Build Ansible Docs
     uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-pr.yml@main
     with:
       collection-name: prometheus.prometheus
@@ -26,7 +44,7 @@ jobs:
       init-title: Prometheus.Prometheus Collection Documentation
       init-html-short-title: Prometheus.Prometheus Collection Docs
       init-extra-html-theme-options: |
-        documentation_home_url=https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/branch/main/
+        documentation_home_url=https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/tag/${{ needs.get-tags.outputs.latest }}
       render-file-line:
         '> * `$<status>`
          [$<path_tail>](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr/${{ github.event.number }}/$<path_tail>)'
@@ -56,7 +74,6 @@ jobs:
         uses: ansible-community/github-docs-build/actions/ansible-docs-build-comment@main
         with:
           body-includes: '## Docs Build'
-          reactions: heart
           action: ${{ needs.build-docs.outputs.changed != 'true' && 'remove' || '' }}
           on-closed-body: |
             ## Docs Build 📝

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -16,10 +16,28 @@ on:
   workflow_dispatch:
 
 jobs:
+  get-tags:
+    runs-on: ubuntu-latest
+    outputs:
+      latest: ${{ steps.get-latest-tag.outputs.latest_tag }}
+    steps:
+      - name: Get the latest tag
+        id: get-latest-tag
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const latestTag = await github.rest.repos.listTags({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 1
+            });
+            core.setOutput('latest_tag', latestTag.data[0].name);
+
   build-docs:
+    name: Build Ansible Docs
+    needs: get-tags
     permissions:
       contents: read
-    name: Build Ansible Docs
     uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-push.yml@main
     with:
       collection-name: prometheus.prometheus
@@ -31,7 +49,7 @@ jobs:
       init-title: Prometheus.Prometheus Collection Documentation
       init-html-short-title: Prometheus.Prometheus Collection Docs
       init-extra-html-theme-options: |
-        documentation_home_url=https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/branch/main/
+        documentation_home_url=https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/tag/${{ needs.get-tags.outputs.latest }}
 
   publish-docs-gh-pages:
     # for now we won't run this on forks


### PR DESCRIPTION
Redirects the docs page to the docs for latest published version instead of the docs for the main branch which may contain unreleased features.

fixes #370 