### PR TITLE
docs: fix config_flags_extra wrong example 

### DIFF
--- a/roles/prometheus/meta/argument_specs.yml
+++ b/roles/prometheus/meta/argument_specs.yml
@@ -68,7 +68,7 @@ argument_specs:
       prometheus_config_flags_extra:
         description:
           - "Additional configuration flags passed to prometheus binary at startup"
-          - "Example: prometheus_config_flags_extra: { storage.tsdb.retention: 15d, alertmanager.timeout: 10s }"
+          - "Example: prometheus_config_flags_extra: { alertmanager.timeout: 10s }"
         type: "dict"
       prometheus_alertmanager_config:
         description:


### PR DESCRIPTION
The prometheus configuration `storage.tsdb.retention` should be setted via `prometheus_storage_retention`. If setted via
`prometheus_config_flags_extra` it throws `duplicating configuration` error.