### PR TITLE
fix: scrape config files path

### DIFF
--- a/roles/prometheus/defaults/main.yml
+++ b/roles/prometheus/defaults/main.yml
@@ -97,8 +97,8 @@ prometheus_static_targets_files:
   - prometheus/targets/*.json
 
 prometheus_scrape_config_files:
-  - prometheus/scrapes/*.yml
-  - prometheus/scrapes/*.json
+  - prometheus/scrape_configs/*.yml
+  - prometheus/scrape_configs/*.json
 
 # yamllint disable rule:line-length
 prometheus_alert_rules:  # noqa yaml[line-length]  # noqa line-length

--- a/roles/prometheus/defaults/main.yml
+++ b/roles/prometheus/defaults/main.yml
@@ -97,8 +97,8 @@ prometheus_static_targets_files:
   - prometheus/targets/*.json
 
 prometheus_scrape_config_files:
-  - prometheus/targets/*.yml
-  - prometheus/targets/*.json
+  - prometheus/scrapes/*.yml
+  - prometheus/scrapes/*.json
 
 # yamllint disable rule:line-length
 prometheus_alert_rules:  # noqa yaml[line-length]  # noqa line-length

--- a/roles/prometheus/meta/argument_specs.yml
+++ b/roles/prometheus/meta/argument_specs.yml
@@ -148,13 +148,13 @@ argument_specs:
           - "prometheus/targets/*.json"
       prometheus_scrape_config_files:
         description:
-          - "List of folders where ansible will look for files containing custom scrape config configuration files which will be copied to C({{ prometheus_config_dir }}/scrapes/)."
+          - "List of folders where ansible will look for files containing custom scrape config configuration files which will be copied to C({{ prometheus_config_dir }}/scrape_configs/)."
           - "This feature is available starting from Prometheus v2.43.0."
         type: "list"
         elements: "str"
         default:
-          - "prometheus/scrapes/*.yml"
-          - "prometheus/scrapes/*.json"
+          - "prometheus/scrape_configs/*.yml"
+          - "prometheus/scrape_configs/*.json"
       prometheus_system_group:
         description:
           - "System group for Prometheus."

--- a/roles/prometheus/molecule/alternative/molecule.yml
+++ b/roles/prometheus/molecule/alternative/molecule.yml
@@ -1,7 +1,5 @@
 ---
 provisioner:
-  playbooks:
-    prepare: "${MOLECULE_PROJECT_DIRECTORY}/../../.config/molecule/alternative/prepare.yml"
   inventory:
     group_vars:
       all:
@@ -58,6 +56,8 @@ provisioner:
                 - influx.example.org:8080
               labels:
                 env: demo
+        prometheus_scrape_config_files:
+          - /tmp/prometheus/scrapes/*.yml
         prometheus_scrape_configs:
           - job_name: "prometheus"
             metrics_path: "{{ prometheus_metrics_path }}"

--- a/roles/prometheus/molecule/alternative/molecule.yml
+++ b/roles/prometheus/molecule/alternative/molecule.yml
@@ -57,7 +57,7 @@ provisioner:
               labels:
                 env: demo
         prometheus_scrape_config_files:
-          - /tmp/prometheus/scrapes/*.yml
+          - /tmp/prometheus/scrape_configs/*.yml
         prometheus_scrape_configs:
           - job_name: "prometheus"
             metrics_path: "{{ prometheus_metrics_path }}"

--- a/roles/prometheus/molecule/alternative/prepare.yml
+++ b/roles/prometheus/molecule/alternative/prepare.yml
@@ -3,15 +3,15 @@
   hosts: localhost
   gather_facts: false
   tasks:
-    - name: Create scrapes directory
+    - name: Create scrape_configs directory
       ansible.builtin.file:
-        name: /tmp/prometheus/scrapes
+        name: /tmp/prometheus/scrape_configs
         state: directory
         recurse: true
       check_mode: false
     - name: Create empty scrape config file
       ansible.builtin.file:
-        name: /tmp/prometheus/scrapes/empty_scrapes.yml
+        name: /tmp/prometheus/scrape_configs/empty_scrapes.yml
         state: touch
         mode: 0664
       check_mode: false

--- a/roles/prometheus/molecule/alternative/prepare.yml
+++ b/roles/prometheus/molecule/alternative/prepare.yml
@@ -1,0 +1,20 @@
+---
+- name: Run local preparation
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Create scrapes directory
+      ansible.builtin.file:
+        name: /tmp/prometheus/scrapes
+        state: directory
+        recurse: true
+      check_mode: false
+    - name: Create empty scrape config file
+      ansible.builtin.file:
+        name: /tmp/prometheus/scrapes/empty_scrapes.yml
+        state: touch
+        mode: 0664
+      check_mode: false
+
+- name: Import shared preparation playbook
+  import_playbook: "../../../../.config/molecule/alternative/prepare.yml"

--- a/roles/prometheus/molecule/alternative/tests/test_alternative.py
+++ b/roles/prometheus/molecule/alternative/tests/test_alternative.py
@@ -7,28 +7,34 @@ import pytest
 testinfra_hosts = get_target_hosts()
 
 
-@pytest.mark.parametrize("dirs", [
-    "/opt/prom/etc",
-    "/opt/prom/etc/rules",
-    "/opt/prom/etc/file_sd",
-    "/opt/prom/etc/scrapes",
-    "/opt/prom/lib"
-])
+@pytest.mark.parametrize(
+    "dirs",
+    [
+        "/opt/prom/etc",
+        "/opt/prom/etc/rules",
+        "/opt/prom/etc/file_sd",
+        "/opt/prom/etc/scrape_configs",
+        "/opt/prom/lib",
+    ],
+)
 def test_directories(host, dirs):
     d = host.file(dirs)
     assert d.is_directory
     assert d.exists
 
 
-@pytest.mark.parametrize("files", [
-    "/opt/prom/etc/prometheus.yml",
-    "/opt/prom/etc/rules/ansible_managed.rules",
-    "/opt/prom/etc/file_sd/node.yml",
-    "/opt/prom/etc/file_sd/docker.yml",
-    "/opt/prom/etc/scrapes/empty_scrapes.yml",
-    "/usr/local/bin/prometheus",
-    "/usr/local/bin/promtool"
-])
+@pytest.mark.parametrize(
+    "files",
+    [
+        "/opt/prom/etc/prometheus.yml",
+        "/opt/prom/etc/rules/ansible_managed.rules",
+        "/opt/prom/etc/file_sd/node.yml",
+        "/opt/prom/etc/file_sd/docker.yml",
+        "/opt/prom/etc/scrape_configs/empty_scrapes.yml",
+        "/usr/local/bin/prometheus",
+        "/usr/local/bin/promtool",
+    ],
+)
 def test_files(host, files):
     f = host.file(files)
     assert f.exists

--- a/roles/prometheus/molecule/alternative/tests/test_alternative.py
+++ b/roles/prometheus/molecule/alternative/tests/test_alternative.py
@@ -11,6 +11,7 @@ testinfra_hosts = get_target_hosts()
     "/opt/prom/etc",
     "/opt/prom/etc/rules",
     "/opt/prom/etc/file_sd",
+    "/opt/prom/etc/scrapes",
     "/opt/prom/lib"
 ])
 def test_directories(host, dirs):
@@ -24,6 +25,7 @@ def test_directories(host, dirs):
     "/opt/prom/etc/rules/ansible_managed.rules",
     "/opt/prom/etc/file_sd/node.yml",
     "/opt/prom/etc/file_sd/docker.yml",
+    "/opt/prom/etc/scrapes/empty_scrapes.yml",
     "/usr/local/bin/prometheus",
     "/usr/local/bin/promtool"
 ])

--- a/roles/prometheus/molecule/default/prepare.yml
+++ b/roles/prometheus/molecule/default/prepare.yml
@@ -1,0 +1,17 @@
+---
+- name: Run local preparation
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Create scrapes directory
+      ansible.builtin.file:
+        name: "{{ playbook_dir }}/../../prometheus/scrapes"
+        state: directory
+        recurse: true
+      check_mode: false
+    - name: Create empty scrape config file
+      ansible.builtin.file:
+        name: "{{ playbook_dir }}/../../prometheus/scrapes/empty_scrapes.yml"
+        state: touch
+        mode: 0664
+      check_mode: false

--- a/roles/prometheus/molecule/default/prepare.yml
+++ b/roles/prometheus/molecule/default/prepare.yml
@@ -3,15 +3,15 @@
   hosts: localhost
   gather_facts: false
   tasks:
-    - name: Create scrapes directory
+    - name: Create scrape_configs directory
       ansible.builtin.file:
-        name: "{{ playbook_dir }}/../../prometheus/scrapes"
+        name: "{{ playbook_dir }}/../../prometheus/scrape_configs"
         state: directory
         recurse: true
       check_mode: false
     - name: Create empty scrape config file
       ansible.builtin.file:
-        name: "{{ playbook_dir }}/../../prometheus/scrapes/empty_scrapes.yml"
+        name: "{{ playbook_dir }}/../../prometheus/scrape_configs/empty_scrapes.yml"
         state: touch
         mode: 0664
       check_mode: false

--- a/roles/prometheus/molecule/default/tests/test_default.py
+++ b/roles/prometheus/molecule/default/tests/test_default.py
@@ -15,15 +15,18 @@ def AnsibleDefaults():
         return yaml.full_load(stream)
 
 
-@pytest.mark.parametrize("dirs", [
-    "/etc/prometheus",
-    "/etc/prometheus/console_libraries",
-    "/etc/prometheus/consoles",
-    "/etc/prometheus/rules",
-    "/etc/prometheus/file_sd",
-    "/etc/prometheus/scrapes",
-    "/var/lib/prometheus"
-])
+@pytest.mark.parametrize(
+    "dirs",
+    [
+        "/etc/prometheus",
+        "/etc/prometheus/console_libraries",
+        "/etc/prometheus/consoles",
+        "/etc/prometheus/rules",
+        "/etc/prometheus/file_sd",
+        "/etc/prometheus/scrape_configs",
+        "/var/lib/prometheus",
+    ],
+)
 def test_directories(host, dirs):
     d = host.file(dirs)
     assert d.is_directory

--- a/roles/prometheus/molecule/default/tests/test_default.py
+++ b/roles/prometheus/molecule/default/tests/test_default.py
@@ -21,6 +21,7 @@ def AnsibleDefaults():
     "/etc/prometheus/consoles",
     "/etc/prometheus/rules",
     "/etc/prometheus/file_sd",
+    "/etc/prometheus/scrapes",
     "/var/lib/prometheus"
 ])
 def test_directories(host, dirs):
@@ -29,14 +30,18 @@ def test_directories(host, dirs):
     assert d.exists
 
 
-@pytest.mark.parametrize("files", [
-    "/etc/prometheus/prometheus.yml",
-    "/etc/prometheus/console_libraries/prom.lib",
-    "/etc/prometheus/consoles/prometheus.html",
-    "/etc/systemd/system/prometheus.service",
-    "/usr/local/bin/prometheus",
-    "/usr/local/bin/promtool"
-])
+@pytest.mark.parametrize(
+    "files",
+    [
+        "/etc/prometheus/prometheus.yml",
+        "/etc/prometheus/console_libraries/prom.lib",
+        "/etc/prometheus/consoles/prometheus.html",
+        "/etc/prometheus/scrape_configs/empty_scrapes.yml",
+        "/etc/systemd/system/prometheus.service",
+        "/usr/local/bin/prometheus",
+        "/usr/local/bin/promtool",
+    ],
+)
 def test_files(host, files):
     f = host.file(files)
     assert f.exists

--- a/roles/prometheus/tasks/configure.yml
+++ b/roles/prometheus/tasks/configure.yml
@@ -135,6 +135,8 @@
     - prometheus
     - configure
     - prometheus_configure
+  notify:
+    - reload prometheus
 
 - name: Copy prometheus custom static targets
   ansible.builtin.copy:
@@ -150,6 +152,8 @@
     - prometheus
     - configure
     - prometheus_configure
+  notify:
+    - reload prometheus
 
 - name: Copy prometheus scrape config files
   ansible.builtin.copy:
@@ -165,3 +169,5 @@
     - prometheus
     - configure
     - prometheus_configure
+  notify:
+    - reload prometheus

--- a/roles/prometheus/tasks/configure.yml
+++ b/roles/prometheus/tasks/configure.yml
@@ -38,7 +38,7 @@
   loop:
     - "{{ prometheus_config_dir }}/rules"
     - "{{ prometheus_config_dir }}/file_sd"
-    - "{{ prometheus_config_dir }}/scrapes"
+    - "{{ prometheus_config_dir }}/scrape_configs"
   become: true
   tags:
     - prometheus
@@ -158,7 +158,7 @@
 - name: Copy prometheus scrape config files
   ansible.builtin.copy:
     src: "{{ item }}"
-    dest: "{{ prometheus_config_dir }}/scrapes/"
+    dest: "{{ prometheus_config_dir }}/scrape_configs/"
     force: true
     owner: "{{ prometheus_system_user }}"
     group: "{{ prometheus_system_group }}"

--- a/roles/prometheus/tasks/configure.yml
+++ b/roles/prometheus/tasks/configure.yml
@@ -171,3 +171,8 @@
     - prometheus_configure
   notify:
     - reload prometheus
+
+- name: Remove "scrapes" folder replaced by "scrape_configs"
+  ansible.builtin.file:
+    path: "{{ prometheus_config_dir }}/scrapes"
+    state: absent

--- a/roles/prometheus/templates/prometheus.yml.j2
+++ b/roles/prometheus/templates/prometheus.yml.j2
@@ -38,6 +38,6 @@ scrape_configs:
 {% if prometheus_version is version('2.43.0', '>=') %}
 {% if prometheus_scrape_config_files != [] %}
 scrape_config_files:
-  - scrapes/*
+  - scrape_configs/*
 {% endif %}
 {% endif %}


### PR DESCRIPTION
Unfortunately simply rebasing the original PR I missed that the paths in the actual role are wrong. I have now updated them ~and took the chance to also re-use the variable's value for the actual configuration not just the glob for copying~.

//edit: Cannot reuse variable since it would lead to `/etc/prometheus/prometheus/scrapes/...`.