### PR TITLE
removed: Drop centos 8 stream support as it is EOL

### DIFF
--- a/.config/molecule/config.yml
+++ b/.config/molecule/config.yml
@@ -23,12 +23,6 @@ platforms:
     privileged: true
     cgroup_parent: docker.slice
     command: /usr/lib/systemd/systemd
-  - name: centos-stream-8
-    image: dokken/centos-stream-8
-    pre_build_image: true
-    privileged: true
-    cgroup_parent: docker.slice
-    command: /lib/systemd/systemd
   - name: centos-stream-9
     image: dokken/centos-stream-9
     pre_build_image: true


### PR DESCRIPTION
Reached EOL 31 May 2024  

https://endoflife.date/centos-stream