### PR TITLE
patch: New oliver006/redis_exporter upstream release 1.61.0!

### DIFF
--- a/.github/scripts/version_updater.sh
+++ b/.github/scripts/version_updater.sh
@@ -90,12 +90,12 @@ esac
 echo_green "New ${source_repo} version is: ${version}"
 
 # Download destination repository
-if grep "_version: ${version}" "roles/${role}/defaults/main.yml"; then
+if grep "^${role}_version: ${version}" "roles/${role}/defaults/main.yml"; then
     echo_green "Newest version is used."
     exit 0
 fi
-sed -i "s/_version:.*$/_version: ${version}/" "roles/${role}/defaults/main.yml"
-sed -i -r "s/_version.*[0-9]+\.[0-9]+\.[0-9]+/_version\` | ${version}/" "roles/${role}/README.md"
+sed -i "s/${role}_version:.*$/${role}_version: ${version}/" "roles/${role}/defaults/main.yml"
+sed -i -r "s/${role}_version.*[0-9]+\.[0-9]+\.[0-9]+/${role}_version\` | ${version}/" "roles/${role}/README.md"
 yq eval -i ".argument_specs.main.options.${role}_version.default = \"${version}\"" "roles/${role}/meta/argument_specs.yml"
 
 update_branch="autoupdate/${role}/${version}"

--- a/roles/redis_exporter/defaults/main.yml
+++ b/roles/redis_exporter/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-redis_exporter_version: 1.58.0
+redis_exporter_version: 1.61.0
 redis_exporter_binary_local_dir: ""
 redis_exporter_binary_url: "https://github.com/{{ _redis_exporter_repo }}/releases/download/v{{ redis_exporter_version }}/\
                            redis_exporter-v{{ redis_exporter_version }}.linux-{{ go_arch }}.tar.gz"

--- a/roles/redis_exporter/meta/argument_specs.yml
+++ b/roles/redis_exporter/meta/argument_specs.yml
@@ -10,7 +10,7 @@ argument_specs:
     options:
       redis_exporter_version:
         description: "redis_exporter package version. Also accepts latest as parameter."
-        default: "1.58.0"
+        default: "1.61.0"
       redis_exporter_skip_install:
         description: "redis_exporter installation tasks gets skipped when set to true."
         type: bool


### PR DESCRIPTION
The upstream [oliver006/redis_exporter](https://github.com/oliver006/redis_exporter/releases) released new software version - **1.61.0**!

This automated PR updates code to bring new version into repository.