### PR TITLE
refactor(ci): split up molecule matrices to avoid job limit 

### DIFF
--- a/.github/workflows/ansible-ci.yml
+++ b/.github/workflows/ansible-ci.yml
@@ -63,24 +63,21 @@ jobs:
     needs:
       - ansible-lint
     outputs:
-      molecule-tests: ${{ steps.set-molecule-tests.outputs.tests }}
       integration-tests: ${{ steps.set-integration-tests.outputs.tests }}
+      ansible-roles: ${{ steps.set-ansible-roles.outputs.roles }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Discover role tests
-        id: set-molecule-tests
+      - name: Discover ansible roles
+        id: set-ansible-roles
         env:
           LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: |
-          roles=$(echo $LABELS | jq -r '.[]' | grep '^roles/' | sed 's|^roles/||')
-          echo tests="[`for role in $roles; do
-            for test in $(find tests/integration/targets -maxdepth 1 -mindepth 1 -type d -iname "molecule-${role}-*" -printf "%f\n"); do
-              echo '{"test":\"'"${test}"'\","name":\"'"${test#*-}\"'"}';
-            done
-          done | tr '\n' ',' | sed '$s/,$//'`]" >> $GITHUB_OUTPUT
+          roles=$(echo $LABELS | jq -c '[.[] | select(startswith("roles/")) | ltrimstr("roles/")]')
+          echo $roles
+          echo "roles=$roles" >> $GITHUB_OUTPUT
 
       - name: Discover integration tests
         id: set-integration-tests
@@ -89,17 +86,20 @@ jobs:
             echo '{"test":\"'"${test}"'\","name":\"'"${test}\"'"}';
           done | tr '\n' ',' | sed '$s/,$//'`]" >> $GITHUB_OUTPUT
 
-  ansible-test-molecule:
-    uses: ./.github/workflows/ansible-test-integration.yml
+  molecule:
+    uses: ./.github/workflows/ansible-test-molecule.yml
     needs:
       - discover-ansible-tests
       - discover-ansible-versions
-    if: needs.discover-ansible-tests.outputs.molecule-tests != '[]' &&
-        needs.discover-ansible-tests.outputs.molecule-tests != ''
+    if: needs.discover-ansible-tests.outputs.ansible-roles != '[]' &&
+        needs.discover-ansible-tests.outputs.ansible-roles != ''
     with:
-      targets: ${{ needs.discover-ansible-tests.outputs.molecule-tests }}
+      role: ${{ matrix.role }}
       ansible-core-versions: ${{ needs.discover-ansible-versions.outputs.versions }}
-      coverage: never
+    strategy:
+      fail-fast: false
+      matrix:
+        role: ${{ fromJson(needs.discover-ansible-tests.outputs.ansible-roles) }}
 
   ansible-test-integration:
     uses: ./.github/workflows/ansible-test-integration.yml

--- a/.github/workflows/ansible-test-molecule.yml
+++ b/.github/workflows/ansible-test-molecule.yml
@@ -1,0 +1,43 @@
+---
+name: Ansible Molecule
+on:
+  workflow_call:
+    inputs:
+      role:
+        required: true
+        type: string
+      ansible-core-versions:
+        required: false
+        default: '["stable-2.14"]'
+        type: string
+
+jobs:
+  discover-molecule-scenarios:
+    runs-on: ubuntu-latest
+    outputs:
+      molecule-tests: ${{ steps.set-molecule-tests.outputs.tests }}
+
+    name: "${{ inputs.role }}-discover-molecule-scenarios"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: "Discover ${{ inputs.role }} molecule scenarios"
+        id: set-molecule-tests
+        run: |
+          role=${{ inputs.role }}
+          echo tests="[`for test in $(find tests/integration/targets -maxdepth 1 -mindepth 1 -type d -iname "molecule-${role}-*" -printf "%f\n"); do
+              echo '{"test":\"'"${test}"'\","name":\"'"${test#*-}\"'"}';
+          done | tr '\n' ',' | sed '$s/,$//'`]" >> $GITHUB_OUTPUT
+
+  ansible-test-integration-molecule:
+    uses: ./.github/workflows/ansible-test-integration.yml
+    needs:
+      - discover-molecule-scenarios
+    if: needs.discover-molecule-scenarios.outputs.molecule-tests != '[]' &&
+        needs.discover-molecule-scenarios.outputs.molecule-tests != ''
+    with:
+      targets: ${{ needs.discover-molecule-scenarios.outputs.molecule-tests }}
+      ansible-core-versions: ${{ inputs.ansible-core-versions }}
+      coverage: never

--- a/.github/workflows/conventional-label.yml
+++ b/.github/workflows/conventional-label.yml
@@ -16,10 +16,9 @@ jobs:
       - name: "Confirm correct pull request title"
         uses: mmubeen/action-pr-title@master  # until PR gets merged https://github.com/deepakputhraya/action-pr-title/pull/29
         with:
-          allowed_prefixes: >-
-            breaking,chore,feat,feature,fix,major,minor,enhancement,
-            deprecated,removed,security,bug,bugfix,docs,packaging,
-            test,refactor,refactoring,skip-release,skip_changelog,patch
+          allowed_prefixes: "breaking,chore,feat,feature,fix,major,minor,enhancement,\
+           deprecated,removed,security,bug,bugfix,docs,packaging,\
+           test,refactor,refactoring,skip-release,skip_changelog,patch"
 
       - name: "Apply label"
         if: github.event.pull_request.labels.length == 0


### PR DESCRIPTION
Creates two matrices, one for the roles and another one for all the scenarios within the roles rather than putting all molecule test runs in a single matrix.
This should fix the 256 job limit we hit when attempting to run all the molecule scenarios on all the roles.