### PR TITLE
enhancement: adding env/container labels options

### DIFF
--- a/roles/cadvisor/defaults/main.yml
+++ b/roles/cadvisor/defaults/main.yml
@@ -11,6 +11,9 @@ cadvisor_prometheus_endpoint: "/metrics"
 
 cadvisor_enable_metrics: []
 cadvisor_disable_metrics: []
+cadvisor_env_metadata_whitelist: []
+cadvisor_whitelisted_container_labels: []
+cadvisor_store_container_labels: true
 cadvisor_docker_only: false
 
 cadvisor_binary_install_dir: "/usr/local/bin"

--- a/roles/cadvisor/meta/argument_specs.yml
+++ b/roles/cadvisor/meta/argument_specs.yml
@@ -64,6 +64,18 @@ argument_specs:
         default: []
         type: "list"
         choices: *metrics_choices
+      cadvisor_store_container_labels:
+        description: "store all container labels"
+        type: "bool"
+        default: true
+      cadvisor_whitelisted_container_labels:
+        description: "comma-separated list of container labels to be used as labels on prometheus metrics"
+        default: []
+        type: "list"
+      cadvisor_env_metadata_whitelist:
+        description: "comma-separated list of env variables to be used as labels on prometheus metrics"
+        default: []
+        type: "list"
       cadvisor_docker_only:
         description: "do not report raw cgroup metrics, except the root cgroup"
         type: "bool"

--- a/roles/cadvisor/molecule/alternative/molecule.yml
+++ b/roles/cadvisor/molecule/alternative/molecule.yml
@@ -13,3 +13,6 @@ provisioner:
           - network
           - cpu
         cadvisor_docker_only: true
+        whitelisted_container_labels: [ "com.docker.compose.image" ]
+        env_metadata_whitelist: [ "PATH" ]
+        store_container_labels: false

--- a/roles/cadvisor/templates/cadvisor.service.j2
+++ b/roles/cadvisor/templates/cadvisor.service.j2
@@ -18,6 +18,13 @@ ExecStart={{ cadvisor_binary_install_dir }}/cadvisor \
 {% if cadvisor_docker_only %}
     '--docker_only={{ cadvisor_docker_only | lower }}' \
 {% endif -%}
+{% if cadvisor_whitelisted_container_labels | length > 0 %}
+    '--whitelisted_container_labels={{ cadvisor_whitelisted_container_labels | join(',') }}' \
+{% endif -%}
+{% if cadvisor_env_metadata_whitelist | length > 0 %}
+    '--env_metadata_whitelist={{ cadvisor_env_metadata_whitelist | join(',') }}' \
+{% endif %}
+    '--store_container_labels={{ cadvisor_store_container_labels | lower }}' \
     '--listen_ip={{ cadvisor_listen_ip }}' \
     '--port={{ cadvisor_port }}' \
     '--prometheus_endpoint={{ cadvisor_prometheus_endpoint }}'


### PR DESCRIPTION
Add following
- cadvisor_env_metadata_whitelist
- cadvisor_whitelisted_container_labels
- cadvisor_store_container_labels

Tested with this simple playbook:
```
---
- name: Install cAdvisor
  hosts: localhost
  become: yes
  tasks:
    - name: Import cAdvisor role
      import_role:
        name: cadvisor
      vars:
        cadvisor_docker_only: true
        cadvisor_enable_metrics: [ "cpu", "memory", "network", "oom_event" ]
        cadvisor_whitelisted_container_labels: [ "com.docker.compose.oneoff" ]
        cadvisor_env_metadata_whitelist: [ "JEKYLL_ENV", "PATH" ]
        cadvisor_store_container_labels: false
```

Also tested dropping the options, which is why I decided to explicitly set store_container_labels: true (which is the cadvisor default).

Closes: #403