### PR TITLE
minor: Update supported Ansible versions

### DIFF
--- a/.config/molecule/config.yml
+++ b/.config/molecule/config.yml
@@ -17,12 +17,6 @@ platforms:
     privileged: true
     cgroup_parent: docker.slice
     command: /lib/systemd/systemd
-  - name: centos-7
-    image: dokken/centos-7
-    pre_build_image: true
-    privileged: true
-    cgroup_parent: docker.slice
-    command: /usr/lib/systemd/systemd
   - name: centos-stream-9
     image: dokken/centos-stream-9
     pre_build_image: true

--- a/.github/scripts/collection_version_parser.py
+++ b/.github/scripts/collection_version_parser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 This module provides functions for parsing PEP 440 compliant

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.9.0,<=2.16.99"
+requires_ansible: ">=2.12.0,<=2.16.99"

--- a/roles/alertmanager/README.md
+++ b/roles/alertmanager/README.md
@@ -8,7 +8,7 @@ Deploy and manage Prometheus [alertmanager](https://github.com/prometheus/alertm
 
 ## Requirements
 
-- Ansible >= 2.9 (It might work on previous versions, but we cannot guarantee it)
+- Ansible >= 2.12 (It might work on previous versions, but we cannot guarantee it)
 
 It would be nice to have prometheus installed somewhere
 

--- a/roles/alertmanager/meta/main.yml
+++ b/roles/alertmanager/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus Alertmanager service"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
@@ -15,7 +15,6 @@ galaxy_info:
         - "buster"
     - name: "EL"
       versions:
-        - "7"
         - "8"
         - "9"
     - name: "Fedora"

--- a/roles/bind_exporter/README.md
+++ b/roles/bind_exporter/README.md
@@ -7,7 +7,7 @@ Deploy prometheus [bind exporter](https://github.com/prometheus-community/bind_e
 
 ## Requirements
 
-- Ansible >= 2.9 (It might work on previous versions, but we cannot guarantee it)
+- Ansible >= 2.12 (It might work on previous versions, but we cannot guarantee it)
 - gnu-tar on Mac deployer host (`brew install gnu-tar`)
 - Passlib is required when using the basic authentication feature (`pip install passlib[bcrypt]`)
 

--- a/roles/bind_exporter/meta/main.yml
+++ b/roles/bind_exporter/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus BIND Exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
@@ -15,7 +15,6 @@ galaxy_info:
         - "buster"
     - name: "EL"
       versions:
-        - "7"
         - "8"
         - "9"
     - name: "Fedora"

--- a/roles/blackbox_exporter/README.md
+++ b/roles/blackbox_exporter/README.md
@@ -8,7 +8,7 @@ Deploy and manage [blackbox exporter](https://github.com/prometheus/blackbox_exp
 
 ## Requirements
 
-- Ansible >= 2.9 (It might work on previous versions, but we cannot guarantee it)
+- Ansible >= 2.12 (It might work on previous versions, but we cannot guarantee it)
 - gnu-tar on Mac deployer host (`brew install gnu-tar`)
 
 ## Role Variables

--- a/roles/blackbox_exporter/meta/main.yml
+++ b/roles/blackbox_exporter/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus Blackbox Exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
@@ -15,7 +15,6 @@ galaxy_info:
         - "buster"
     - name: "EL"
       versions:
-        - "7"
         - "8"
         - "9"
     - name: "Fedora"

--- a/roles/cadvisor/README.md
+++ b/roles/cadvisor/README.md
@@ -8,7 +8,7 @@ Deploy [cadvisor](https://github.com/google/cadvisor) using ansible.
 
 ## Requirements
 
-- Ansible >= 2.9 (It might work on previous versions, but we cannot guarantee it)
+- Ansible >= 2.12 (It might work on previous versions, but we cannot guarantee it)
 - gnu-tar on Mac deployer host (`brew install gnu-tar`)
 - Passlib is required when using the basic authentication feature (`pip install passlib[bcrypt]`)
 

--- a/roles/cadvisor/meta/main.yml
+++ b/roles/cadvisor/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "cAdvisor Authors"
   description: "cAdvisor"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
@@ -15,7 +15,6 @@ galaxy_info:
         - "buster"
     - name: "EL"
       versions:
-        - "7"
         - "8"
         - "9"
     - name: "Fedora"

--- a/roles/chrony_exporter/README.md
+++ b/roles/chrony_exporter/README.md
@@ -8,7 +8,7 @@ Deploy prometheus [chrony_exporter](https://github.com/superq/chrony_exporter) u
 
 ## Requirements
 
-- Ansible >= 2.9 (It might work on previous versions, but we cannot guarantee it)
+- Ansible >= 2.12 (It might work on previous versions, but we cannot guarantee it)
 - gnu-tar on Mac deployer host (`brew install gnu-tar`)
 - Passlib is required when using the basic authentication feature (`pip install passlib[bcrypt]`)
 

--- a/roles/chrony_exporter/meta/main.yml
+++ b/roles/chrony_exporter/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus Chrony Exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
@@ -15,7 +15,6 @@ galaxy_info:
         - "buster"
     - name: "EL"
       versions:
-        - "7"
         - "8"
         - "9"
     - name: "Fedora"

--- a/roles/fail2ban_exporter/README.md
+++ b/roles/fail2ban_exporter/README.md
@@ -8,7 +8,7 @@ Deploy prometheus [fail2ban_exporter](https://gitlab.com/hectorjsmith/fail2ban-p
 
 ## Requirements
 
-- Ansible >= 2.9 (It might work on previous versions, but we cannot guarantee it)
+- Ansible >= 2.12 (It might work on previous versions, but we cannot guarantee it)
 - gnu-tar on Mac deployer host (`brew install gnu-tar`)
 - Passlib is required when using the basic authentication feature (`pip install passlib[bcrypt]`)
 

--- a/roles/fail2ban_exporter/meta/main.yml
+++ b/roles/fail2ban_exporter/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus fail2ban_exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
@@ -15,7 +15,6 @@ galaxy_info:
         - "buster"
     - name: "EL"
       versions:
-        - "7"
         - "8"
         - "9"
     - name: "Fedora"

--- a/roles/ipmi_exporter/README.md
+++ b/roles/ipmi_exporter/README.md
@@ -8,7 +8,7 @@ Deploy prometheus [ipmi_exporter](https://github.com/prometheus-community/ipmi_e
 
 ## Requirements
 
-- Ansible >= 2.9 (It might work on previous versions, but we cannot guarantee it)
+- Ansible >= 2.12 (It might work on previous versions, but we cannot guarantee it)
 - gnu-tar on Mac deployer host (`brew install gnu-tar`)
 - Passlib is required when using the basic authentication feature (`pip install passlib[bcrypt]`)
 

--- a/roles/ipmi_exporter/meta/main.yml
+++ b/roles/ipmi_exporter/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus ipmi_exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
@@ -15,7 +15,6 @@ galaxy_info:
         - "buster"
     - name: "EL"
       versions:
-        - "7"
         - "8"
         - "9"
     - name: "Fedora"

--- a/roles/memcached_exporter/README.md
+++ b/roles/memcached_exporter/README.md
@@ -8,7 +8,7 @@ Deploy prometheus [memcached_exporter](https://github.com/prometheus/memcached_e
 
 ## Requirements
 
-- Ansible >= 2.9 (It might work on previous versions, but we cannot guarantee it)
+- Ansible >= 2.12 (It might work on previous versions, but we cannot guarantee it)
 - gnu-tar on Mac deployer host (`brew install gnu-tar`)
 - Passlib is required when using the basic authentication feature (`pip install passlib[bcrypt]`)
 

--- a/roles/memcached_exporter/meta/main.yml
+++ b/roles/memcached_exporter/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus memcached_exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
@@ -15,7 +15,6 @@ galaxy_info:
         - "buster"
     - name: "EL"
       versions:
-        - "7"
         - "8"
         - "9"
     - name: "Fedora"

--- a/roles/mongodb_exporter/README.md
+++ b/roles/mongodb_exporter/README.md
@@ -8,7 +8,7 @@ Deploy prometheus [mongodb_exporter](https://github.com/percona/mongodb_exporter
 
 ## Requirements
 
-- Ansible >= 2.9 (It might work on previous versions, but we cannot guarantee it)
+- Ansible >= 2.12 (It might work on previous versions, but we cannot guarantee it)
 - gnu-tar on Mac deployer host (`brew install gnu-tar`)
 - Passlib is required when using the basic authentication feature (`pip install passlib[bcrypt]`)
 

--- a/roles/mongodb_exporter/meta/main.yml
+++ b/roles/mongodb_exporter/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus mongodb_exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
@@ -15,7 +15,6 @@ galaxy_info:
         - "buster"
     - name: "EL"
       versions:
-        - "7"
         - "8"
         - "9"
     - name: "Fedora"

--- a/roles/mysqld_exporter/README.md
+++ b/roles/mysqld_exporter/README.md
@@ -7,7 +7,7 @@ Deploy prometheus [mysql exporter](https://github.com/prometheus/mysqld_exporter
 
 ## Requirements
 
-- Ansible >= 2.9 (It might work on previous versions, but we cannot guarantee it)
+- Ansible >= 2.12 (It might work on previous versions, but we cannot guarantee it)
 - gnu-tar on Mac deployer host (`brew install gnu-tar`)
 - Passlib is required when using the basic authentication feature (`pip install passlib[bcrypt]`)
 

--- a/roles/mysqld_exporter/meta/main.yml
+++ b/roles/mysqld_exporter/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus MySQLd Exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
@@ -15,7 +15,6 @@ galaxy_info:
         - "buster"
     - name: "EL"
       versions:
-        - "7"
         - "8"
         - "9"
     - name: "Fedora"

--- a/roles/nginx_exporter/README.md
+++ b/roles/nginx_exporter/README.md
@@ -8,7 +8,7 @@ Deploy prometheus [nginx_exporter](https://github.com/nginxinc/nginx-prometheus-
 
 ## Requirements
 
-- Ansible >= 2.9 (It might work on previous versions, but we cannot guarantee it)
+- Ansible >= 2.12 (It might work on previous versions, but we cannot guarantee it)
 - gnu-tar on Mac deployer host (`brew install gnu-tar`)
 - Passlib is required when using the basic authentication feature (`pip install passlib[bcrypt]`)
 

--- a/roles/nginx_exporter/meta/main.yml
+++ b/roles/nginx_exporter/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus nginx_exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
@@ -15,7 +15,6 @@ galaxy_info:
         - "buster"
     - name: "EL"
       versions:
-        - "7"
         - "8"
         - "9"
     - name: "Fedora"

--- a/roles/node_exporter/README.md
+++ b/roles/node_exporter/README.md
@@ -8,7 +8,7 @@ Deploy prometheus [node exporter](https://github.com/prometheus/node_exporter) u
 
 ## Requirements
 
-- Ansible >= 2.9 (It might work on previous versions, but we cannot guarantee it)
+- Ansible >= 2.12 (It might work on previous versions, but we cannot guarantee it)
 - gnu-tar on Mac deployer host (`brew install gnu-tar`)
 - Passlib is required when using the basic authentication feature (`pip install passlib[bcrypt]`)
 

--- a/roles/node_exporter/meta/main.yml
+++ b/roles/node_exporter/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus Node Exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
@@ -15,7 +15,6 @@ galaxy_info:
         - "buster"
     - name: "EL"
       versions:
-        - "7"
         - "8"
         - "9"
     - name: "Fedora"

--- a/roles/postgres_exporter/README.md
+++ b/roles/postgres_exporter/README.md
@@ -7,7 +7,7 @@ Deploy prometheus [postgresql exporter](https://github.com/prometheus-community/
 
 ## Requirements
 
-- Ansible >= 2.9 (It might work on previous versions, but we cannot guarantee it)
+- Ansible >= 2.12 (It might work on previous versions, but we cannot guarantee it)
 - gnu-tar on Mac deployer host (`brew install gnu-tar`)
 - Passlib is required when using the basic authentication feature (`pip install passlib[bcrypt]`)
 

--- a/roles/postgres_exporter/meta/main.yml
+++ b/roles/postgres_exporter/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus PostgreSQL Exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
@@ -15,7 +15,6 @@ galaxy_info:
         - "buster"
     - name: "EL"
       versions:
-        - "7"
         - "8"
         - "9"
     - name: "Fedora"

--- a/roles/process_exporter/README.md
+++ b/roles/process_exporter/README.md
@@ -8,7 +8,7 @@ Note. This repository and role uses the name process_exporter to conform with an
 
 ## Requirements
 
-- Ansible >= 2.9 (It might work on previous versions, but we cannot guarantee it)
+- Ansible >= 2.12 (It might work on previous versions, but we cannot guarantee it)
 
 ## Role Variables
 

--- a/roles/process_exporter/meta/main.yml
+++ b/roles/process_exporter/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus Process Exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
@@ -15,7 +15,6 @@ galaxy_info:
         - "buster"
     - name: "EL"
       versions:
-        - "7"
         - "8"
         - "9"
     - name: "Fedora"

--- a/roles/prometheus/README.md
+++ b/roles/prometheus/README.md
@@ -8,7 +8,7 @@ Deploy [Prometheus](https://github.com/prometheus/prometheus) monitoring system 
 
 ## Requirements
 
-- Ansible >= "2.9" (It might work on previous versions, but we cannot guarantee it)
+- Ansible >= "2.12" (It might work on previous versions, but we cannot guarantee it)
 - gnu-tar on Mac deployer host (`brew install gnu-tar`)
 
 ## Role Variables

--- a/roles/prometheus/meta/main.yml
+++ b/roles/prometheus/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus monitoring system configuration and management"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
@@ -15,7 +15,6 @@ galaxy_info:
         - "buster"
     - name: "EL"
       versions:
-        - "7"
         - "8"
         - "9"
     - name: "Fedora"

--- a/roles/pushgateway/README.md
+++ b/roles/pushgateway/README.md
@@ -8,7 +8,7 @@ Deploy prometheus [pushgateway](https://github.com/prometheus/pushgateway) using
 
 ## Requirements
 
-- Ansible >= 2.9 (It might work on previous versions, but we cannot guarantee it)
+- Ansible >= 2.12 (It might work on previous versions, but we cannot guarantee it)
 - gnu-tar on Mac deployer host (`brew install gnu-tar`)
 - Passlib is required when using the basic authentication feature (`pip install passlib[bcrypt]`)
 

--- a/roles/pushgateway/meta/main.yml
+++ b/roles/pushgateway/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus Pushgateway"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
@@ -15,7 +15,6 @@ galaxy_info:
         - "buster"
     - name: "EL"
       versions:
-        - "7"
         - "8"
         - "9"
     - name: "Fedora"

--- a/roles/redis_exporter/README.md
+++ b/roles/redis_exporter/README.md
@@ -8,7 +8,7 @@ Deploy prometheus [redis_exporter](https://github.com/oliver006/redis_exporter/)
 
 ## Requirements
 
-- Ansible >= 2.9 (It might work on previous versions, but we cannot guarantee it)
+- Ansible >= 2.12 (It might work on previous versions, but we cannot guarantee it)
 - gnu-tar on Mac deployer host (`brew install gnu-tar`)
 
 ## Role Variables

--- a/roles/redis_exporter/meta/main.yml
+++ b/roles/redis_exporter/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus redis_exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
@@ -15,7 +15,6 @@ galaxy_info:
         - "buster"
     - name: "EL"
       versions:
-        - "7"
         - "8"
         - "9"
     - name: "Fedora"

--- a/roles/smartctl_exporter/README.md
+++ b/roles/smartctl_exporter/README.md
@@ -8,7 +8,7 @@ Deploy prometheus [smartctl_exporter](https://github.com/prometheus-community/sm
 
 ## Requirements
 
-- Ansible >= 2.9 (It might work on previous versions, but we cannot guarantee it)
+- Ansible >= 2.12 (It might work on previous versions, but we cannot guarantee it)
 - gnu-tar on Mac deployer host (`brew install gnu-tar`)
 - Passlib is required when using the basic authentication feature (`pip install passlib[bcrypt]`)
 

--- a/roles/smartctl_exporter/meta/main.yml
+++ b/roles/smartctl_exporter/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus Smartctl Exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
@@ -15,7 +15,6 @@ galaxy_info:
         - "buster"
     - name: "EL"
       versions:
-        - "7"
         - "8"
         - "9"
     - name: "Fedora"

--- a/roles/smokeping_prober/README.md
+++ b/roles/smokeping_prober/README.md
@@ -6,7 +6,7 @@ Deploy prometheus [smokeping_prober](https://github.com/superq/smokeping_prober)
 
 ## Requirements
 
-- Ansible >= 2.9 (It might work on previous versions, but we cannot guarantee it)
+- Ansible >= 2.12 (It might work on previous versions, but we cannot guarantee it)
 - gnu-tar on Mac deployer host (`brew install gnu-tar`)
 - Passlib is required when using the basic authentication feature (`pip install passlib[bcrypt]`)
 

--- a/roles/smokeping_prober/meta/main.yml
+++ b/roles/smokeping_prober/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus Smokeping Prober"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
@@ -15,7 +15,6 @@ galaxy_info:
         - "buster"
     - name: "EL"
       versions:
-        - "7"
         - "8"
         - "9"
     - name: "Fedora"

--- a/roles/snmp_exporter/README.md
+++ b/roles/snmp_exporter/README.md
@@ -8,7 +8,7 @@ Deploy and manage prometheus [SNMP exporter](https://github.com/prometheus/snmp_
 
 ## Requirements
 
-- Ansible >= 2.9 (It might work on previous versions, but we cannot guarantee it)
+- Ansible >= 2.12 (It might work on previous versions, but we cannot guarantee it)
 
 ## Role Variables
 

--- a/roles/snmp_exporter/meta/main.yml
+++ b/roles/snmp_exporter/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus SNMP Exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
@@ -15,7 +15,6 @@ galaxy_info:
         - "buster"
     - name: "EL"
       versions:
-        - "7"
         - "8"
         - "9"
     - name: "Fedora"

--- a/roles/systemd_exporter/README.md
+++ b/roles/systemd_exporter/README.md
@@ -8,7 +8,7 @@ Deploy prometheus [systemd exporter](https://github.com/prometheus-community/sys
 
 ## Requirements
 
-- Ansible >= 2.9 (It might work on previous versions, but we cannot guarantee it)
+- Ansible >= 2.12 (It might work on previous versions, but we cannot guarantee it)
 - gnu-tar on Mac deployer host (`brew install gnu-tar`)
 
 ## Role Variables

--- a/roles/systemd_exporter/meta/main.yml
+++ b/roles/systemd_exporter/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus Systemd Exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
@@ -16,7 +16,6 @@ galaxy_info:
         - "buster"
     - name: "EL"
       versions:
-        - "7"
         - "8"
         - "9"
     - name: "Fedora"

--- a/tests/integration/molecule.sh
+++ b/tests/integration/molecule.sh
@@ -51,5 +51,5 @@ unset _ANSIBLE_COVERAGE_CONFIG
 unset ANSIBLE_PYTHON_INTERPRETER
 
 # Run molecule test
-cd "$role_root"
+cd "${role_root}" || exit 1
 molecule -c "$collection_root/.config/molecule/config.yml" test -s "$scenario"

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,1 +1,0 @@
-.github/scripts/collection_version_parser.py shebang  # https://github.com/ansible/ansible/issues/78346

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,1 +1,0 @@
-.github/scripts/collection_version_parser.py shebang  # https://github.com/ansible/ansible/issues/78346

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,1 +1,0 @@
-.github/scripts/collection_version_parser.py shebang  # https://github.com/ansible/ansible/issues/78346

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,1 +1,0 @@
-.github/scripts/collection_version_parser.py shebang  # https://github.com/ansible/ansible/issues/78346

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,1 +1,0 @@
-.github/scripts/collection_version_parser.py shebang  # https://github.com/ansible/ansible/issues/78346

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,1 +1,0 @@
-.github/scripts/collection_version_parser.py shebang  # https://github.com/ansible/ansible/issues/78346

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,1 +1,0 @@
-.github/scripts/collection_version_parser.py shebang  # https://github.com/ansible/ansible/issues/78346

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,1 +1,0 @@
-.github/scripts/collection_version_parser.py shebang  # https://github.com/ansible/ansible/issues/78346


### PR DESCRIPTION
Ansible versions 2.11 and older are not supportable on new platforms. Set the minimum supported Ansible version to 2.12 in order to make updating our integration testing possible.
* Fixup minor linting issues.