### PR TITLE
minor: bump support for ansible from v2.16.* to v2.17.*

### DIFF
--- a/.config/molecule/config.yml
+++ b/.config/molecule/config.yml
@@ -88,3 +88,6 @@ provisioner:
           - "2.9"
           - "2.10"
           - "2.11"
+      almalinux-8:
+        exclude_ansible_vers:
+          - "2.17"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.9.0,<=2.16.99"
+requires_ansible: ">=2.9.0,<=2.17.99"

--- a/tests/integration/molecule.sh
+++ b/tests/integration/molecule.sh
@@ -51,5 +51,5 @@ unset _ANSIBLE_COVERAGE_CONFIG
 unset ANSIBLE_PYTHON_INTERPRETER
 
 # Run molecule test
-cd "$role_root"
+cd "$role_root" || { echo "Fail to change directory into $role_root"; exit 1; }
 molecule -c "$collection_root/.config/molecule/config.yml" test -s "$scenario"

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,0 +1,1 @@
+.github/scripts/collection_version_parser.py shebang  # https://github.com/ansible/ansible/issues/78346


### PR DESCRIPTION
## Context

Fix #386

## Last version bump

The last version bump was in https://github.com/prometheus-community/ansible/commit/2e0a30de1aecf46d046e24e2e4a9bff454696305
It is not clear to me, why the version was set down to 2.16.* (from 2.17)

A lot of changes has been between Ansible v2.16.10 and v2.17.3, see https://github.com/ansible/ansible/compare/v2.16.10...v2.17.3

## Ansible version

The following ansible version is used with v0.17.1 of the ansible role `prometheus.prometheus`:

```
ansible [core 2.17.3]
  config file = None
  configured module search path = ['/Users/andy.grunwald/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/homebrew/Cellar/ansible/10.3.0/libexec/lib/python3.12/site-packages/ansible
  ansible collection location = /Users/andy.grunwald/.ansible/collections:/usr/share/ansible/collections
  executable location = /opt/homebrew/bin/ansible
  python version = 3.12.5 (main, Aug  6 2024, 19:08:49) [Clang 15.0.0 (clang-1500.3.9.4)] (/opt/homebrew/Cellar/ansible/10.3.0/libexec/bin/python)
  jinja version = 3.1.4
  libyaml = True
```