### PR TITLE
fix: ansible-community/eol-ansible for 2.9/2.10/2.11 tests

### DIFF
--- a/.github/workflows/ansible-test-integration.yml
+++ b/.github/workflows/ansible-test-integration.yml
@@ -42,5 +42,7 @@ jobs:
           testing-type: integration
           target: ${{ matrix.targets.test }}
           coverage: ${{ inputs.coverage }}
+          ansible-core-github-repository-slug: ${{ contains(fromJson('["stable-2.9", "stable-2.10", "stable-2.11"]'), matrix.ansible-core-versions) &&
+                                               'ansible-community/eol-ansible' || 'ansible/ansible' }}
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/ansible-test-sanity.yml
+++ b/.github/workflows/ansible-test-sanity.yml
@@ -23,3 +23,5 @@ jobs:
         with:
           ansible-core-version: ${{ matrix.ansible-core-versions }}
           testing-type: sanity
+          ansible-core-github-repository-slug: ${{ contains(fromJson('["stable-2.9", "stable-2.10", "stable-2.11"]'), matrix.ansible-core-versions) &&
+                                               'ansible-community/eol-ansible' || 'ansible/ansible' }}


### PR DESCRIPTION
Previously committed in https://github.com/prometheus-community/ansible/pull/395 but that one needs more work.