### PR TITLE
fix(process_exporter): skip install when there's nothing to do

### DIFF
--- a/roles/process_exporter/tasks/main.yml
+++ b/roles/process_exporter/tasks/main.yml
@@ -19,6 +19,13 @@
       become: true
       tags:
         - process_exporter_install
+  when:
+    ( not __process_exporter_is_installed.stat.exists ) or
+    ( (__process_exporter_current_version_output.stderr_lines | length > 0)
+      and (__process_exporter_current_version_output.stderr_lines[0].split(" ")[2] != process_exporter_version) ) or
+    ( (__process_exporter_current_version_output.stdout_lines | length > 0)
+      and (__process_exporter_current_version_output.stdout_lines[0].split(" ")[2] != process_exporter_version) ) or
+    ( process_exporter_binary_local_dir | length > 0 )
   tags:
     - process_exporter_install
 


### PR DESCRIPTION
Just like in `roles/node_exporter/tasks/main.yml`: the install tasks can be skipped conditionally when process_exporter is already installed and reports the same version as the expected one.

This short patch is basically a copy-paste from [roles/node_exporter/tasks/main.yml](https://github.com/prometheus-community/ansible/blob/main/roles/node_exporter/tasks/main.yml#L22) with the variables updated.