### PR TITLE
minor(ci): detect unused ansible variables

### DIFF
--- a/.github/scripts/discover_role_repos.sh
+++ b/.github/scripts/discover_role_repos.sh
@@ -3,9 +3,16 @@
 # Description: Discover the upstream repo from each role default vars.
 
 result=$(
-  for defaults_file in roles/*/vars/main.yml ; do
-    role="$(echo "${defaults_file}" | cut -f2 -d'/')"
-    yq eval "[{\"repo\": ._${role}_repo, \"role\": \"${role}\", \"type\": ._${role}_repo_type // \"github\"}]" "${defaults_file}"
+  for role_dir in roles/*/ ; do
+    role="$(basename "${role_dir}")"
+
+    role_repo=$(yq eval "._${role}_repo" "${role_dir}/vars/main.yml" 2>/dev/null)
+
+    yq eval "[{
+      \"repo\": \"${role_repo}\",
+      \"role\": \"${role}\",
+      \"type\": (.${role}_binary_url | split(\"/\")[2] | split(\".\")[0] // \"github\")
+    }]" "${role_dir}/defaults/main.yml" 2>/dev/null
   done | yq -o json -I=0
 )
 

--- a/.github/workflows/ansible-ci.yml
+++ b/.github/workflows/ansible-ci.yml
@@ -38,6 +38,13 @@ jobs:
       - name: Lint arguments spec
         run: ./.github/scripts/lint_arguments_spec.sh
 
+  check-unused-variables:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run action
+        uses: hoo29/little-timmy@v1-action
+
   discover-ansible-versions:
     runs-on: ubuntu-latest
     outputs:

--- a/roles/fail2ban_exporter/vars/main.yml
+++ b/roles/fail2ban_exporter/vars/main.yml
@@ -8,4 +8,3 @@ go_arch_map:
 
 go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
 _fail2ban_exporter_repo: 24199687
-_fail2ban_exporter_repo_type: gitlab

--- a/roles/smokeping_prober/defaults/main.yml
+++ b/roles/smokeping_prober/defaults/main.yml
@@ -7,7 +7,6 @@ smokeping_prober_checksums_url: "https://github.com/{{ _smokeping_prober_repo }}
 smokeping_prober_skip_install: false
 
 smokeping_prober_web_listen_address: "0.0.0.0:9374"
-smokeping_prober_web_telemetry_path: "/metrics"
 
 # List of smokeping_prober targets.
 # See: https://github.com/SuperQ/smokeping_prober/#configuration

--- a/roles/smokeping_prober/meta/argument_specs.yml
+++ b/roles/smokeping_prober/meta/argument_specs.yml
@@ -29,9 +29,6 @@ argument_specs:
       smokeping_prober_web_listen_address:
         description: "Address on which Smokeping Prober will listen"
         default: "0.0.0.0:9374"
-      smokeping_prober_web_telemetry_path:
-        description: "Path under which to expose metrics"
-        default: "/metrics"
       smokeping_prober_config_dir:
         description: "The directory of the smokeping_prober probes config files"
         default: "/etc/smokeping_prober"


### PR DESCRIPTION
Use [little-timmy](https://github.com/hoo29/little-timmy) for detecting unused variables in the ansible roles.