### PR TITLE
fix: make sure binary install dir exists

### DIFF
--- a/roles/_common/tasks/install.yml
+++ b/roles/_common/tasks/install.yml
@@ -104,6 +104,24 @@
       check_mode: false
       when: __common_binary_basename is search('\.zip$|\.tar\.gz$')
 
+- name: "Check existence of binary install dir"
+  ansible.builtin.stat:
+    path: "{{ _common_binary_install_dir }}"
+  register: __common_binary_install_dir
+
+- name: "Make sure binary install dir exists"
+  ansible.builtin.file:
+    path: "{{ _common_binary_install_dir }}"
+    mode: 0755
+    owner: root
+    group: root
+  become: true
+  tags:
+    - "{{ ansible_parent_role_names | first | regex_replace(ansible_collection_name ~ '.', '') }}"
+    - install
+    - "{{ ansible_parent_role_names | first | regex_replace(ansible_collection_name ~ '.', '') }}_install"
+  when: not __common_binary_install_dir.stat.exists
+
 - name: "Propagate binaries"
   ansible.builtin.copy:
     src: "{{ _common_local_cache_path }}/{{ item }}"


### PR DESCRIPTION
I'm trying to install node_exporter on a remote host with a custom `node_exporter_binary_install_dir`.

```
- hosts: all
  roles:
    - prometheus.prometheus.node_exporter
  vars:
    node_exporter_binary_local_dir: /home/namsic/downloads/node_exporter-1.6.0.linux-amd64
    node_exporter_binary_install_dir: /home/namsic/tmp
```

But when I ran the above playbook, I got the following result:
```
TASK [prometheus.prometheus.node_exporter : Propagate locally distributed node_exporter binary] ****************************************************************************************************************************************************************************************************************************************************************************
fatal: [remote001]: FAILED! => {
    "changed": false,
    "checksum": "894db4cbc1bda8d686d73f33f22c57c861836c9d",
    "msg": "Destination directory /home/namsic/tmp does not exist"
}
```

If there are multiple target hosts, it would be nice to automatically create the directory if it does not exist.

If these changes are not appropriate, please let me know.

Thanks.