### PR TITLE
removed: variables for skipping install in favor of tags

### DIFF
--- a/roles/alertmanager/defaults/main.yml
+++ b/roles/alertmanager/defaults/main.yml
@@ -4,7 +4,6 @@ alertmanager_binary_local_dir: ''
 alertmanager_binary_url: "https://github.com/{{ _alertmanager_repo }}/releases/download/v{{ alertmanager_version }}/\
                           alertmanager-{{ alertmanager_version }}.linux-{{ go_arch }}.tar.gz"
 alertmanager_checksums_url: "https://github.com/{{ _alertmanager_repo }}/releases/download/v{{ alertmanager_version }}/sha256sums.txt"
-alertmanager_skip_install: false
 
 alertmanager_config_dir: /etc/alertmanager
 alertmanager_db_dir: /var/lib/alertmanager

--- a/roles/alertmanager/meta/argument_specs.yml
+++ b/roles/alertmanager/meta/argument_specs.yml
@@ -11,10 +11,6 @@ argument_specs:
       alertmanager_version:
         description: "Alertmanager package version. Also accepts `latest` as parameter."
         default: 0.27.0
-      alertmanager_skip_install:
-        description: "Alertmanager installation tasks gets skipped when set to true."
-        type: bool
-        default: false
       alertmanager_binary_local_dir:
         description:
           - "Allows to use local packages instead of ones distributed on github."

--- a/roles/alertmanager/tasks/install.yml
+++ b/roles/alertmanager/tasks/install.yml
@@ -29,7 +29,8 @@
 - name: Get binary
   when:
     - alertmanager_binary_local_dir | length == 0
-    - not alertmanager_skip_install
+  tags:
+    - alertmanager_install
   block:
 
     - name: Download alertmanager binary to local folder
@@ -82,6 +83,7 @@
     - amtool
   when:
     - alertmanager_binary_local_dir | length > 0
-    - not alertmanager_skip_install
   notify:
     - restart alertmanager
+  tags:
+    - alertmanager_install

--- a/roles/alertmanager/tasks/preflight.yml
+++ b/roles/alertmanager/tasks/preflight.yml
@@ -41,6 +41,13 @@
           list |
           length == 0
 
+- name: "Check for deprecated skip_install variable"
+  ansible.builtin.assert:
+    that:
+      - alertmanager_skip_install is not defined
+    fail_msg: "The variable 'alertmanager_skip_install' is deprecated.
+               Please use '--skip-tags alertmanager_install' instead to skip the installation."
+
 - name: Discover latest version
   ansible.builtin.set_fact:
     alertmanager_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _alertmanager_repo }}/releases/latest', headers=_github_api_headers,
@@ -51,12 +58,14 @@
   when:
     - alertmanager_version == "latest"
     - alertmanager_binary_local_dir | length == 0
-    - not alertmanager_skip_install
+  tags:
+    - alertmanager_install
 
 - name: Get alertmanager binary checksum
   when:
     - alertmanager_binary_local_dir | length == 0
-    - not alertmanager_skip_install
+  tags:
+    - alertmanager_install
   block:
     - name: "Get checksum list"
       ansible.builtin.set_fact:

--- a/roles/bind_exporter/defaults/main.yml
+++ b/roles/bind_exporter/defaults/main.yml
@@ -4,7 +4,6 @@ bind_exporter_binary_local_dir: ""
 bind_exporter_binary_url: "https://github.com/{{ _bind_exporter_repo }}/releases/download/v{{ bind_exporter_version }}/\
                            bind_exporter-{{ bind_exporter_version }}.linux-{{ go_arch }}.tar.gz"
 bind_exporter_checksums_url: "https://github.com/{{ _bind_exporter_repo }}/releases/download/v{{ bind_exporter_version }}/sha256sums.txt"
-bind_exporter_skip_install: false
 
 bind_exporter_web_listen_address: "0.0.0.0:9119"
 bind_exporter_web_telemetry_path: "/metrics"

--- a/roles/bind_exporter/meta/argument_specs.yml
+++ b/roles/bind_exporter/meta/argument_specs.yml
@@ -11,10 +11,6 @@ argument_specs:
       bind_exporter_version:
         description: "BIND exporter package version. Also accepts latest as parameter."
         default: "0.7.0"
-      bind_exporter_skip_install:
-        description: "BIND installation tasks gets skipped when set to true."
-        type: bool
-        default: false
       bind_exporter_binary_local_dir:
         description:
           - "Enables the use of local packages instead of those distributed on github."

--- a/roles/bind_exporter/tasks/install.yml
+++ b/roles/bind_exporter/tasks/install.yml
@@ -20,7 +20,8 @@
 - name: Get binary
   when:
     - bind_exporter_binary_local_dir | length == 0
-    - not bind_exporter_skip_install
+  tags:
+    - bind_exporter_install
   block:
 
     - name: Download bind_exporter binary to local folder
@@ -67,5 +68,6 @@
     group: root
   when:
     - bind_exporter_binary_local_dir | length > 0
-    - not bind_exporter_skip_install
   notify: restart bind_exporter
+  tags:
+    - bind_exporter_install

--- a/roles/bind_exporter/tasks/preflight.yml
+++ b/roles/bind_exporter/tasks/preflight.yml
@@ -20,6 +20,13 @@
   ansible.builtin.package_facts:
   when: "not 'packages' in ansible_facts"
 
+- name: "Check for deprecated skip_install variable"
+  ansible.builtin.assert:
+    that:
+      - bind_exporter_skip_install is not defined
+    fail_msg: "The variable 'bind_exporter_skip_install' is deprecated.
+               Please use '--skip-tags bind_exporter_install' instead to skip the installation."
+
 - name: Naive assertion of proper listen address
   ansible.builtin.assert:
     that:
@@ -82,12 +89,14 @@
   when:
     - bind_exporter_version == "latest"
     - bind_exporter_binary_local_dir | length == 0
-    - not bind_exporter_skip_install
+  tags:
+    - bind_exporter_install
 
 - name: Get bind_exporter binary checksum
   when:
     - bind_exporter_binary_local_dir | length == 0
-    - not bind_exporter_skip_install
+  tags:
+    - bind_exporter_install
   block:
     - name: Get checksum list from github
       ansible.builtin.set_fact:

--- a/roles/blackbox_exporter/defaults/main.yml
+++ b/roles/blackbox_exporter/defaults/main.yml
@@ -5,7 +5,6 @@ blackbox_exporter_binary_url: "https://github.com/{{ _blackbox_exporter_repo }}/
                                blackbox_exporter-{{ blackbox_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] |
                                default(ansible_architecture) }}.tar.gz"
 blackbox_exporter_checksums_url: "https://github.com/{{ _blackbox_exporter_repo }}/releases/download/v{{ blackbox_exporter_version }}/sha256sums.txt"
-blackbox_exporter_skip_install: false
 
 blackbox_exporter_web_listen_address: "0.0.0.0:9115"
 

--- a/roles/blackbox_exporter/meta/argument_specs.yml
+++ b/roles/blackbox_exporter/meta/argument_specs.yml
@@ -11,10 +11,6 @@ argument_specs:
       blackbox_exporter_version:
         description: "Blackbox exporter package version. Also accepts latest as parameter."
         default: "0.25.0"
-      blackbox_exporter_skip_install:
-        description: "Blackbox exporter installation tasks gets skipped when set to true."
-        type: bool
-        default: false
       blackbox_exporter_binary_local_dir:
         description:
           - "Enables the use of local packages instead of those distributed on github."

--- a/roles/blackbox_exporter/tasks/install.yml
+++ b/roles/blackbox_exporter/tasks/install.yml
@@ -18,7 +18,8 @@
 - name: Get binary
   when:
     - blackbox_exporter_binary_local_dir | length == 0
-    - not blackbox_exporter_skip_install
+  tags:
+    - blackbox_exporter_install
   block:
 
     - name: Download blackbox_exporter binary to local folder
@@ -63,8 +64,9 @@
     group: root
   when:
     - blackbox_exporter_binary_local_dir | length > 0
-    - not blackbox_exporter_skip_install
   notify: restart blackbox_exporter
+  tags:
+    - blackbox_exporter_install
 
 - name: Install libcap on Debian systems
   ansible.builtin.package:

--- a/roles/blackbox_exporter/tasks/preflight.yml
+++ b/roles/blackbox_exporter/tasks/preflight.yml
@@ -41,6 +41,13 @@
           list |
           length == 0
 
+- name: "Check for deprecated skip_install variable"
+  ansible.builtin.assert:
+    that:
+      - blackbox_exporter_skip_install is not defined
+    fail_msg: "The variable 'blackbox_exporter_skip_install' is deprecated.
+               Please use '--skip-tags blackbox_exporter_install' instead to skip the installation."
+
 - name: Discover latest version
   ansible.builtin.set_fact:
     blackbox_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _blackbox_exporter_repo }}/releases/latest', headers=_github_api_headers,
@@ -51,12 +58,14 @@
   when:
     - blackbox_exporter_version == "latest"
     - blackbox_exporter_binary_local_dir | length == 0
-    - not blackbox_exporter_skip_install
+  tags:
+    - blackbox_exporter_install
 
 - name: Get blackbox_exporter binary checksum
   when:
     - blackbox_exporter_binary_local_dir | length == 0
-    - not blackbox_exporter_skip_install
+  tags:
+    - blackbox_exporter_install
   block:
     - name: Get checksum list from github
       ansible.builtin.set_fact:

--- a/roles/cadvisor/defaults/main.yml
+++ b/roles/cadvisor/defaults/main.yml
@@ -3,7 +3,6 @@ cadvisor_version: 0.49.1
 cadvisor_binary_local_dir: ""
 cadvisor_binary_url: "https://github.com/{{ _cadvisor_repo }}/releases/download/v{{ cadvisor_version }}/\
                       cadvisor-v{{ cadvisor_version }}-linux-{{ go_arch }}"
-cadvisor_skip_install: false
 
 cadvisor_listen_ip: "0.0.0.0"
 cadvisor_port: "8080"

--- a/roles/cadvisor/meta/argument_specs.yml
+++ b/roles/cadvisor/meta/argument_specs.yml
@@ -11,10 +11,6 @@ argument_specs:
       cadvisor_version:
         description: "cAdvisor package version. Also accepts latest as parameter."
         default: "0.49.1"
-      cadvisor_skip_install:
-        description: "cAdvisor installation tasks gets skipped when set to true."
-        type: bool
-        default: false
       cadvisor_binary_local_dir:
         description:
           - "Enables the use of local packages instead of those distributed on github."

--- a/roles/cadvisor/tasks/install.yml
+++ b/roles/cadvisor/tasks/install.yml
@@ -20,7 +20,8 @@
 - name: Get binary
   when:
     - cadvisor_binary_local_dir | length == 0
-    - not cadvisor_skip_install
+  tags:
+    - cadvisor_install
   block:
 
     - name: Download cadvisor binary to local folder
@@ -55,5 +56,6 @@
     group: root
   when:
     - cadvisor_binary_local_dir | length > 0
-    - not cadvisor_skip_install
   notify: restart cadvisor
+  tags:
+    - cadvisor_install

--- a/roles/cadvisor/tasks/preflight.yml
+++ b/roles/cadvisor/tasks/preflight.yml
@@ -20,6 +20,13 @@
   ansible.builtin.package_facts:
   when: "not 'packages' in ansible_facts"
 
+- name: "Check for deprecated skip_install variable"
+  ansible.builtin.assert:
+    that:
+      - cadvisor_skip_install is not defined
+    fail_msg: "The variable 'cadvisor_skip_install' is deprecated.
+               Please use '--skip-tags cadvisor_install' instead to skip the installation."
+
 - name: Check if cadvisor is installed
   ansible.builtin.stat:
     path: "{{ cadvisor_binary_install_dir }}/cadvisor"
@@ -47,4 +54,5 @@
   when:
     - cadvisor_version == "latest"
     - cadvisor_binary_local_dir | length == 0
-    - not cadvisor_skip_install
+  tags:
+    - cadvisor_install

--- a/roles/chrony_exporter/defaults/main.yml
+++ b/roles/chrony_exporter/defaults/main.yml
@@ -4,7 +4,6 @@ chrony_exporter_binary_local_dir: ""
 chrony_exporter_binary_url: "https://github.com/{{ _chrony_exporter_repo }}/releases/download/v{{ chrony_exporter_version }}/\
                            chrony_exporter-{{ chrony_exporter_version }}.linux-{{ go_arch }}.tar.gz"
 chrony_exporter_checksums_url: "https://github.com/{{ _chrony_exporter_repo }}/releases/download/v{{ chrony_exporter_version }}/sha256sums.txt"
-chrony_exporter_skip_install: false
 
 chrony_exporter_web_listen_address: "0.0.0.0:9123"
 chrony_exporter_web_telemetry_path: "/metrics"

--- a/roles/chrony_exporter/meta/argument_specs.yml
+++ b/roles/chrony_exporter/meta/argument_specs.yml
@@ -11,10 +11,6 @@ argument_specs:
       chrony_exporter_version:
         description: "Chrony exporter package version. Also accepts latest as parameter."
         default: "0.10.1"
-      chrony_exporter_skip_install:
-        description: "Chrony exporter installation tasks gets skipped when set to true."
-        type: bool
-        default: false
       chrony_exporter_binary_local_dir:
         description:
           - "Enables the use of local packages instead of those distributed on github."

--- a/roles/chrony_exporter/tasks/install.yml
+++ b/roles/chrony_exporter/tasks/install.yml
@@ -20,7 +20,8 @@
 - name: Get binary
   when:
     - chrony_exporter_binary_local_dir | length == 0
-    - not chrony_exporter_skip_install
+  tags:
+    - chrony_exporter_install
   block:
 
     - name: Download chrony_exporter binary to local folder
@@ -65,5 +66,6 @@
     group: root
   when:
     - chrony_exporter_binary_local_dir | length > 0
-    - not chrony_exporter_skip_install
   notify: restart chrony_exporter
+  tags:
+    - chrony_exporter_install

--- a/roles/chrony_exporter/tasks/preflight.yml
+++ b/roles/chrony_exporter/tasks/preflight.yml
@@ -20,6 +20,13 @@
   ansible.builtin.package_facts:
   when: "not 'packages' in ansible_facts"
 
+- name: "Check for deprecated skip_install variable"
+  ansible.builtin.assert:
+    that:
+      - chrony_exporter_skip_install is not defined
+    fail_msg: "The variable 'chrony_exporter_skip_install' is deprecated.
+               Please use '--skip-tags chrony_exporter_install' instead to skip the installation."
+
 - name: Assert that used version supports listen address type
   ansible.builtin.assert:
     that:
@@ -99,12 +106,14 @@
   when:
     - chrony_exporter_version == "latest"
     - chrony_exporter_binary_local_dir | length == 0
-    - not chrony_exporter_skip_install
+  tags:
+    - chrony_exporter_install
 
 - name: Get chrony_exporter binary checksum
   when:
     - chrony_exporter_binary_local_dir | length == 0
-    - not chrony_exporter_skip_install
+  tags:
+    - chrony_exporter_install
   block:
     - name: Get checksum list from github
       ansible.builtin.set_fact:

--- a/roles/fail2ban_exporter/defaults/main.yml
+++ b/roles/fail2ban_exporter/defaults/main.yml
@@ -5,7 +5,6 @@ fail2ban_exporter_binary_url: "https://gitlab.com/hectorjsmith/fail2ban-promethe
                                fail2ban_exporter_{{ fail2ban_exporter_version }}_linux_{{ go_arch }}.tar.gz"
 fail2ban_exporter_checksums_url: "https://gitlab.com/hectorjsmith/fail2ban-prometheus-exporter/-/releases/v{{ fail2ban_exporter_version }}/downloads/\
                                fail2ban_exporter_{{ fail2ban_exporter_version }}_checksums.txt"
-fail2ban_exporter_skip_install: false
 
 fail2ban_exporter_web_listen_address: "0.0.0.0:9191"
 fail2ban_exporter_socket: "/var/run/fail2ban/fail2ban.sock"

--- a/roles/fail2ban_exporter/meta/argument_specs.yml
+++ b/roles/fail2ban_exporter/meta/argument_specs.yml
@@ -11,10 +11,6 @@ argument_specs:
       fail2ban_exporter_version:
         description: "fail2ban_exporter package version. Also accepts latest as parameter."
         default: "0.10.1"
-      fail2ban_exporter_skip_install:
-        description: "fail2ban_exporter installation tasks gets skipped when set to true."
-        type: bool
-        default: false
       fail2ban_exporter_binary_local_dir:
         description:
           - "Enables the use of local packages instead of those distributed on gitlab."

--- a/roles/fail2ban_exporter/tasks/install.yml
+++ b/roles/fail2ban_exporter/tasks/install.yml
@@ -2,7 +2,8 @@
 - name: Get binary
   when:
     - fail2ban_exporter_binary_local_dir | length == 0
-    - not fail2ban_exporter_skip_install
+  tags:
+    - fail2ban_exporter_install
   block:
 
     - name: Download fail2ban_exporter binary to local folder
@@ -47,5 +48,6 @@
     group: root
   when:
     - fail2ban_exporter_binary_local_dir | length > 0
-    - not fail2ban_exporter_skip_install
   notify: restart fail2ban_exporter
+  tags:
+    - fail2ban_exporter_install

--- a/roles/fail2ban_exporter/tasks/preflight.yml
+++ b/roles/fail2ban_exporter/tasks/preflight.yml
@@ -20,6 +20,13 @@
   ansible.builtin.package_facts:
   when: "not 'packages' in ansible_facts"
 
+- name: "Check for deprecated skip_install variable"
+  ansible.builtin.assert:
+    that:
+      - fail2ban_exporter_skip_install is not defined
+    fail_msg: "The variable 'fail2ban_exporter_skip_install' is deprecated.
+               Please use '--skip-tags fail2ban_exporter_install' instead to skip the installation."
+
 - name: Assert that used version supports listen address type
   ansible.builtin.assert:
     that:
@@ -63,12 +70,14 @@
   when:
     - fail2ban_exporter_version == "latest"
     - fail2ban_exporter_binary_local_dir | length == 0
-    - not fail2ban_exporter_skip_install
+  tags:
+    - fail2ban_exporter_install
 
 - name: Get fail2ban_exporter binary checksum
   when:
     - fail2ban_exporter_binary_local_dir | length == 0
-    - not fail2ban_exporter_skip_install
+  tags:
+    - fail2ban_exporter_install
   block:
     - name: Get checksum list from gitlab
       ansible.builtin.set_fact:

--- a/roles/ipmi_exporter/defaults/main.yml
+++ b/roles/ipmi_exporter/defaults/main.yml
@@ -4,7 +4,6 @@ ipmi_exporter_binary_local_dir: ""
 ipmi_exporter_binary_url: "https://github.com/{{ _ipmi_exporter_repo }}/releases/download/v{{ ipmi_exporter_version }}/\
                            ipmi_exporter-{{ ipmi_exporter_version }}.linux-{{ go_arch }}.tar.gz"
 ipmi_exporter_checksums_url: "https://github.com/{{ _ipmi_exporter_repo }}/releases/download/v{{ ipmi_exporter_version }}/sha256sums.txt"
-ipmi_exporter_skip_install: false
 
 ipmi_exporter_modules:
   default:

--- a/roles/ipmi_exporter/meta/argument_specs.yml
+++ b/roles/ipmi_exporter/meta/argument_specs.yml
@@ -11,10 +11,6 @@ argument_specs:
       ipmi_exporter_version:
         description: "ipmi_exporter package version. Also accepts latest as parameter."
         default: "1.8.0"
-      ipmi_exporter_skip_install:
-        description: "ipmi_exporter installation tasks gets skipped when set to true."
-        type: bool
-        default: false
       ipmi_exporter_binary_local_dir:
         description:
           - "Enables the use of local packages instead of those distributed on github."

--- a/roles/ipmi_exporter/tasks/install.yml
+++ b/roles/ipmi_exporter/tasks/install.yml
@@ -20,7 +20,8 @@
 - name: Get binary
   when:
     - ipmi_exporter_binary_local_dir | length == 0
-    - not ipmi_exporter_skip_install
+  tags:
+    - ipmi_exporter_install
   block:
 
     - name: Download ipmi_exporter binary to local folder
@@ -65,8 +66,9 @@
     group: root
   when:
     - ipmi_exporter_binary_local_dir | length > 0
-    - not ipmi_exporter_skip_install
   notify: restart ipmi_exporter
+  tags:
+    - ipmi_exporter_install
 
 - name: Install freeipmi package
   ansible.builtin.package:

--- a/roles/ipmi_exporter/tasks/preflight.yml
+++ b/roles/ipmi_exporter/tasks/preflight.yml
@@ -20,6 +20,13 @@
   ansible.builtin.package_facts:
   when: "not 'packages' in ansible_facts"
 
+- name: "Check for deprecated skip_install variable"
+  ansible.builtin.assert:
+    that:
+      - ipmi_exporter_skip_install is not defined
+    fail_msg: "The variable 'ipmi_exporter_skip_install' is deprecated.
+               Please use '--skip-tags ipmi_exporter_install' instead to skip the installation."
+
 - name: Assert that used version supports listen address type
   ansible.builtin.assert:
     that:
@@ -88,12 +95,14 @@
   when:
     - ipmi_exporter_version == "latest"
     - ipmi_exporter_binary_local_dir | length == 0
-    - not ipmi_exporter_skip_install
+  tags:
+    - ipmi_exporter_install
 
 - name: Get ipmi_exporter binary checksum
   when:
     - ipmi_exporter_binary_local_dir | length == 0
-    - not ipmi_exporter_skip_install
+  tags:
+    - ipmi_exporter_install
   block:
     - name: Get checksum list from github
       ansible.builtin.set_fact:

--- a/roles/memcached_exporter/defaults/main.yml
+++ b/roles/memcached_exporter/defaults/main.yml
@@ -4,7 +4,6 @@ memcached_exporter_binary_local_dir: ""
 memcached_exporter_binary_url: "https://github.com/{{ _memcached_exporter_repo }}/releases/download/v{{ memcached_exporter_version }}/\
                            memcached_exporter-{{ memcached_exporter_version }}.linux-{{ go_arch }}.tar.gz"
 memcached_exporter_checksums_url: "https://github.com/{{ _memcached_exporter_repo }}/releases/download/v{{ memcached_exporter_version }}/sha256sums.txt"
-memcached_exporter_skip_install: false
 
 memcached_exporter_memcached_pid_file: ""
 

--- a/roles/memcached_exporter/meta/argument_specs.yml
+++ b/roles/memcached_exporter/meta/argument_specs.yml
@@ -11,10 +11,6 @@ argument_specs:
       memcached_exporter_version:
         description: "memcached_exporter package version. Also accepts latest as parameter."
         default: "0.14.4"
-      memcached_exporter_skip_install:
-        description: "memcached_exporter installation tasks gets skipped when set to true."
-        type: bool
-        default: false
       memcached_exporter_binary_local_dir:
         description:
           - "Enables the use of local packages instead of those distributed on github."

--- a/roles/memcached_exporter/tasks/install.yml
+++ b/roles/memcached_exporter/tasks/install.yml
@@ -20,7 +20,8 @@
 - name: Get binary
   when:
     - memcached_exporter_binary_local_dir | length == 0
-    - not memcached_exporter_skip_install
+  tags:
+    - memcached_exporter_install
   block:
 
     - name: Download memcached_exporter binary to local folder
@@ -65,5 +66,6 @@
     group: root
   when:
     - memcached_exporter_binary_local_dir | length > 0
-    - not memcached_exporter_skip_install
   notify: restart memcached_exporter
+  tags:
+    - memcached_exporter_install

--- a/roles/memcached_exporter/tasks/preflight.yml
+++ b/roles/memcached_exporter/tasks/preflight.yml
@@ -61,6 +61,13 @@
           - "__memcached_exporter_cert_file.stat.exists"
           - "__memcached_exporter_key_file.stat.exists"
 
+- name: "Check for deprecated skip_install variable"
+  ansible.builtin.assert:
+    that:
+      - memcached_exporter_skip_install is not defined
+    fail_msg: "The variable 'memcached_exporter_skip_install' is deprecated.
+               Please use '--skip-tags memcached_exporter_install' instead to skip the installation."
+
 - name: Check if memcached_exporter is installed
   ansible.builtin.stat:
     path: "{{ memcached_exporter_binary_install_dir }}/memcached_exporter"
@@ -88,12 +95,14 @@
   when:
     - memcached_exporter_version == "latest"
     - memcached_exporter_binary_local_dir | length == 0
-    - not memcached_exporter_skip_install
+  tags:
+    - memcached_exporter_install
 
 - name: Get memcached_exporter binary checksum
   when:
     - memcached_exporter_binary_local_dir | length == 0
-    - not memcached_exporter_skip_install
+  tags:
+    - memcached_exporter_install
   block:
     - name: Get checksum list from github
       ansible.builtin.set_fact:

--- a/roles/mongodb_exporter/defaults/main.yml
+++ b/roles/mongodb_exporter/defaults/main.yml
@@ -5,7 +5,6 @@ mongodb_exporter_binary_url: "https://github.com/{{ _mongodb_exporter_repo }}/re
                           mongodb_exporter-{{ mongodb_exporter_version }}.linux-{{ go_arch }}.tar.gz"
 mongodb_exporter_checksums_url: "https://github.com/{{ _mongodb_exporter_repo }}/releases/download/v{{ mongodb_exporter_version }}/\
                           mongodb_exporter_{{ mongodb_exporter_version }}_checksums.txt"
-mongodb_exporter_skip_install: false
 
 mongodb_exporter_web_listen_address: "0.0.0.0:9216"
 mongodb_exporter_web_telemetry_path: "/metrics"

--- a/roles/mongodb_exporter/meta/argument_specs.yml
+++ b/roles/mongodb_exporter/meta/argument_specs.yml
@@ -11,10 +11,6 @@ argument_specs:
       mongodb_exporter_version:
         description: "mongodb_exporter package version. Also accepts latest as parameter."
         default: "0.41.1"
-      mongodb_exporter_skip_install:
-        description: "mongodb_exporter installation tasks gets skipped when set to true."
-        type: bool
-        default: false
       mongodb_exporter_binary_local_dir:
         description:
           - "Enables the use of local packages instead of those distributed on github."

--- a/roles/mongodb_exporter/tasks/install.yml
+++ b/roles/mongodb_exporter/tasks/install.yml
@@ -20,7 +20,8 @@
 - name: Get binary
   when:
     - mongodb_exporter_binary_local_dir | length == 0
-    - not mongodb_exporter_skip_install
+  tags:
+    - mongodb_exporter_install
   block:
 
     - name: Download mongodb_exporter binary to local folder
@@ -65,5 +66,6 @@
     group: root
   when:
     - mongodb_exporter_binary_local_dir | length > 0
-    - not mongodb_exporter_skip_install
   notify: restart mongodb_exporter
+  tags:
+    - mongodb_exporter_install

--- a/roles/mongodb_exporter/tasks/preflight.yml
+++ b/roles/mongodb_exporter/tasks/preflight.yml
@@ -61,6 +61,13 @@
           - "__mongodb_exporter_cert_file.stat.exists"
           - "__mongodb_exporter_key_file.stat.exists"
 
+- name: "Check for deprecated skip_install variable"
+  ansible.builtin.assert:
+    that:
+      - mongodb_exporter_skip_install is not defined
+    fail_msg: "The variable 'mongodb_exporter_skip_install' is deprecated.
+               Please use '--skip-tags mongodb_exporter_install' instead to skip the installation."
+
 - name: Check if mongodb_exporter is installed
   ansible.builtin.stat:
     path: "{{ mongodb_exporter_binary_install_dir }}/mongodb_exporter"
@@ -88,12 +95,14 @@
   when:
     - mongodb_exporter_version == "latest"
     - mongodb_exporter_binary_local_dir | length == 0
-    - not mongodb_exporter_skip_install
+  tags:
+    - mongodb_exporter_install
 
 - name: Get mongodb_exporter binary checksum
   when:
     - mongodb_exporter_binary_local_dir | length == 0
-    - not mongodb_exporter_skip_install
+  tags:
+    - mongodb_exporter_install
   block:
     - name: Get checksum list from github
       ansible.builtin.set_fact:

--- a/roles/mysqld_exporter/defaults/main.yml
+++ b/roles/mysqld_exporter/defaults/main.yml
@@ -4,7 +4,6 @@ mysqld_exporter_binary_local_dir: ""
 mysqld_exporter_binary_url: "https://github.com/{{ _mysqld_exporter_repo }}/releases/download/v{{ mysqld_exporter_version }}/\
                            mysqld_exporter-{{ mysqld_exporter_version }}.linux-{{ go_arch }}.tar.gz"
 mysqld_exporter_checksums_url: "https://github.com/{{ _mysqld_exporter_repo }}/releases/download/v{{ mysqld_exporter_version }}/sha256sums.txt"
-mysqld_exporter_skip_install: false
 
 mysqld_exporter_web_listen_address: "0.0.0.0:9104"
 mysqld_exporter_web_telemetry_path: "/metrics"

--- a/roles/mysqld_exporter/meta/argument_specs.yml
+++ b/roles/mysqld_exporter/meta/argument_specs.yml
@@ -11,10 +11,6 @@ argument_specs:
       mysqld_exporter_version:
         description: "MySQLd exporter package version. Also accepts latest as parameter."
         default: "0.15.1"
-      mysqld_exporter_skip_install:
-        description: "MySQLd installation tasks gets skipped when set to true."
-        type: bool
-        default: false
       mysqld_exporter_binary_local_dir:
         description:
           - "Enables the use of local packages instead of those distributed on github."

--- a/roles/mysqld_exporter/tasks/install.yml
+++ b/roles/mysqld_exporter/tasks/install.yml
@@ -20,7 +20,8 @@
 - name: Get binary
   when:
     - mysqld_exporter_binary_local_dir | length == 0
-    - not mysqld_exporter_skip_install
+  tags:
+    - mysqld_exporter_install
   block:
 
     - name: Download mysqld_exporter binary to local folder
@@ -67,5 +68,6 @@
     group: root
   when:
     - mysqld_exporter_binary_local_dir | length > 0
-    - not mysqld_exporter_skip_install
   notify: restart mysqld_exporter
+  tags:
+    - mysqld_exporter_install

--- a/roles/mysqld_exporter/tasks/preflight.yml
+++ b/roles/mysqld_exporter/tasks/preflight.yml
@@ -20,6 +20,13 @@
   ansible.builtin.package_facts:
   when: "not 'packages' in ansible_facts"
 
+- name: "Check for deprecated skip_install variable"
+  ansible.builtin.assert:
+    that:
+      - mysqld_exporter_skip_install is not defined
+    fail_msg: "The variable 'mysqld_exporter_skip_install' is deprecated.
+               Please use '--skip-tags mysqld_exporter_install' instead to skip the installation."
+
 - name: Assert that used version supports listen address type
   ansible.builtin.assert:
     that:
@@ -99,12 +106,14 @@
   when:
     - mysqld_exporter_version == "latest"
     - mysqld_exporter_binary_local_dir | length == 0
-    - not mysqld_exporter_skip_install
+  tags:
+    - mysqld_exporter_install
 
 - name: Get mysqld_exporter binary checksum
   when:
     - mysqld_exporter_binary_local_dir | length == 0
-    - not mysqld_exporter_skip_install
+  tags:
+    - mysqld_exporter_install
   block:
     - name: Get checksum list from github
       ansible.builtin.set_fact:

--- a/roles/nginx_exporter/defaults/main.yml
+++ b/roles/nginx_exporter/defaults/main.yml
@@ -5,7 +5,6 @@ nginx_exporter_binary_url: "https://github.com/{{ _nginx_exporter_repo }}/releas
                           nginx-prometheus-exporter_{{ nginx_exporter_version }}_linux_{{ go_arch }}.tar.gz"
 nginx_exporter_checksums_url: "https://github.com/{{ _nginx_exporter_repo }}/releases/download/v{{ nginx_exporter_version }}/\
                           nginx-prometheus-exporter_{{ nginx_exporter_version }}_checksums.txt"
-nginx_exporter_skip_install: false
 nginx_exporter_plus: false
 nginx_exporter_scrape_uri: "http://127.0.0.1/stub_status"
 nginx_exporter_web_listen_address: "0.0.0.0:9113"

--- a/roles/nginx_exporter/meta/argument_specs.yml
+++ b/roles/nginx_exporter/meta/argument_specs.yml
@@ -11,10 +11,6 @@ argument_specs:
       nginx_exporter_version:
         description: "nginx_exporter package version. Also accepts latest as parameter."
         default: "1.3.0"
-      nginx_exporter_skip_install:
-        description: "nginx_exporter installation tasks gets skipped when set to true."
-        type: bool
-        default: false
       nginx_exporter_plus:
         description: "Start the exporter for NGINX Plus."
         type: bool

--- a/roles/nginx_exporter/tasks/install.yml
+++ b/roles/nginx_exporter/tasks/install.yml
@@ -20,7 +20,8 @@
 - name: Get binary
   when:
     - nginx_exporter_binary_local_dir | length == 0
-    - not nginx_exporter_skip_install
+  tags:
+    - nginx_exporter_install
   block:
 
     - name: Download nginx_exporter binary to local folder
@@ -65,5 +66,6 @@
     group: root
   when:
     - nginx_exporter_binary_local_dir | length > 0
-    - not nginx_exporter_skip_install
   notify: restart nginx_exporter
+  tags:
+    - nginx_exporter_install

--- a/roles/nginx_exporter/tasks/preflight.yml
+++ b/roles/nginx_exporter/tasks/preflight.yml
@@ -61,6 +61,13 @@
           - "__nginx_exporter_cert_file.stat.exists"
           - "__nginx_exporter_key_file.stat.exists"
 
+- name: "Check for deprecated skip_install variable"
+  ansible.builtin.assert:
+    that:
+      - nginx_exporter_skip_install is not defined
+    fail_msg: "The variable 'nginx_exporter_skip_install' is deprecated.
+               Please use '--skip-tags nginx_exporter_install' instead to skip the installation."
+
 - name: Check if nginx_exporter is installed
   ansible.builtin.stat:
     path: "{{ nginx_exporter_binary_install_dir }}/nginx_exporter"
@@ -88,12 +95,14 @@
   when:
     - nginx_exporter_version == "latest"
     - nginx_exporter_binary_local_dir | length == 0
-    - not nginx_exporter_skip_install
+  tags:
+    - nginx_exporter_install
 
 - name: Get nginx_exporter binary checksum
   when:
     - nginx_exporter_binary_local_dir | length == 0
-    - not nginx_exporter_skip_install
+  tags:
+    - nginx_exporter_install
   block:
     - name: Get checksum list from github
       ansible.builtin.set_fact:

--- a/roles/node_exporter/defaults/main.yml
+++ b/roles/node_exporter/defaults/main.yml
@@ -4,7 +4,6 @@ node_exporter_binary_local_dir: ""
 node_exporter_binary_url: "https://github.com/{{ _node_exporter_repo }}/releases/download/v{{ node_exporter_version }}/\
                            node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
 node_exporter_checksums_url: "https://github.com/{{ _node_exporter_repo }}/releases/download/v{{ node_exporter_version }}/sha256sums.txt"
-node_exporter_skip_install: false
 
 node_exporter_web_disable_exporter_metrics: false
 node_exporter_web_listen_address: "0.0.0.0:9100"

--- a/roles/node_exporter/meta/argument_specs.yml
+++ b/roles/node_exporter/meta/argument_specs.yml
@@ -11,10 +11,6 @@ argument_specs:
       node_exporter_version:
         description: "Node exporter package version. Also accepts latest as parameter."
         default: "1.8.2"
-      node_exporter_skip_install:
-        description: "Node exporter installation tasks gets skipped when set to true."
-        type: bool
-        default: false
       node_exporter_binary_local_dir:
         description:
           - "Enables the use of local packages instead of those distributed on github."

--- a/roles/node_exporter/tasks/install.yml
+++ b/roles/node_exporter/tasks/install.yml
@@ -20,7 +20,8 @@
 - name: Get binary
   when:
     - node_exporter_binary_local_dir | length == 0
-    - not node_exporter_skip_install
+  tags:
+    - node_exporter_install
   block:
 
     - name: Download node_exporter binary to local folder
@@ -65,5 +66,6 @@
     group: root
   when:
     - node_exporter_binary_local_dir | length > 0
-    - not node_exporter_skip_install
   notify: restart node_exporter
+  tags:
+    - node_exporter_install

--- a/roles/node_exporter/tasks/preflight.yml
+++ b/roles/node_exporter/tasks/preflight.yml
@@ -20,6 +20,13 @@
   ansible.builtin.package_facts:
   when: "not 'packages' in ansible_facts"
 
+- name: "Check for deprecated skip_install variable"
+  ansible.builtin.assert:
+    that:
+      - node_exporter_skip_install is not defined
+    fail_msg: "The variable 'node_exporter_skip_install' is deprecated.
+               Please use '--skip-tags node_exporter_install' instead to skip the installation."
+
 - name: Assert that used version supports listen address type
   ansible.builtin.assert:
     that:
@@ -99,12 +106,14 @@
   when:
     - node_exporter_version == "latest"
     - node_exporter_binary_local_dir | length == 0
-    - not node_exporter_skip_install
+  tags:
+    - node_exporter_install
 
 - name: Get node_exporter binary checksum
   when:
     - node_exporter_binary_local_dir | length == 0
-    - not node_exporter_skip_install
+  tags:
+    - node_exporter_install
   block:
     - name: Get checksum list from github
       ansible.builtin.set_fact:

--- a/roles/postgres_exporter/defaults/main.yml
+++ b/roles/postgres_exporter/defaults/main.yml
@@ -4,7 +4,6 @@ postgres_exporter_binary_local_dir: ""
 postgres_exporter_binary_url: "https://github.com/{{ _postgres_exporter_repo }}/releases/download/v{{ postgres_exporter_version }}/\
                            postgres_exporter-{{ postgres_exporter_version }}.linux-{{ go_arch }}.tar.gz"
 postgres_exporter_checksums_url: "https://github.com/{{ _postgres_exporter_repo }}/releases/download/v{{ postgres_exporter_version }}/sha256sums.txt"
-postgres_exporter_skip_install: false
 
 postgres_exporter_web_listen_address: "0.0.0.0:9187"
 postgres_exporter_web_telemetry_path: "/metrics"

--- a/roles/postgres_exporter/meta/argument_specs.yml
+++ b/roles/postgres_exporter/meta/argument_specs.yml
@@ -11,10 +11,6 @@ argument_specs:
       postgres_exporter_version:
         description: "PostgreSQL exporter package version. Also accepts latest as parameter."
         default: "0.15.0"
-      postgres_exporter_skip_install:
-        description: "PostgreSQL installation tasks gets skipped when set to true."
-        type: bool
-        default: false
       postgres_exporter_binary_local_dir:
         description:
           - "Enables the use of local packages instead of those distributed on github."

--- a/roles/postgres_exporter/tasks/install.yml
+++ b/roles/postgres_exporter/tasks/install.yml
@@ -20,7 +20,8 @@
 - name: Get binary
   when:
     - postgres_exporter_binary_local_dir | length == 0
-    - not postgres_exporter_skip_install
+  tags:
+    - postgres_exporter_install
   block:
 
     - name: Download postgres_exporter binary to local folder
@@ -67,5 +68,6 @@
     group: root
   when:
     - postgres_exporter_binary_local_dir | length > 0
-    - not postgres_exporter_skip_install
   notify: restart postgres_exporter
+  tags:
+    - postgres_exporter_install

--- a/roles/postgres_exporter/tasks/preflight.yml
+++ b/roles/postgres_exporter/tasks/preflight.yml
@@ -20,6 +20,13 @@
   ansible.builtin.package_facts:
   when: "not 'packages' in ansible_facts"
 
+- name: "Check for deprecated skip_install variable"
+  ansible.builtin.assert:
+    that:
+      - postgres_exporter_skip_install is not defined
+    fail_msg: "The variable 'postgres_exporter_skip_install' is deprecated.
+               Please use '--skip-tags postgres_exporter_install' instead to skip the installation."
+
 - name: Assert that used version supports listen address type
   ansible.builtin.assert:
     that:
@@ -99,12 +106,14 @@
   when:
     - postgres_exporter_version == "latest"
     - postgres_exporter_binary_local_dir | length == 0
-    - not postgres_exporter_skip_install
+  tags:
+    - postgres_exporter_install
 
 - name: Get postgres_exporter binary checksum
   when:
     - postgres_exporter_binary_local_dir | length == 0
-    - not postgres_exporter_skip_install
+  tags:
+    - postgres_exporter_install
   block:
     - name: Get checksum list from github
       ansible.builtin.set_fact:

--- a/roles/process_exporter/defaults/main.yml
+++ b/roles/process_exporter/defaults/main.yml
@@ -4,7 +4,6 @@ process_exporter_binary_local_dir: ""
 process_exporter_binary_url: "https://github.com/{{ _process_exporter_repo }}/releases/download/v{{ process_exporter_version }}/\
                               process-exporter-{{ process_exporter_version }}.linux-{{ go_arch }}.tar.gz"
 process_exporter_checksums_url: "https://github.com/{{ _process_exporter_repo }}/releases/download/v{{ process_exporter_version }}/checksums.txt"
-process_exporter_skip_install: false
 process_exporter_archive_path: /tmp
 
 

--- a/roles/process_exporter/meta/argument_specs.yml
+++ b/roles/process_exporter/meta/argument_specs.yml
@@ -11,10 +11,6 @@ argument_specs:
       process_exporter_version:
         description: "Process exporter package version. Also accepts latest as parameter."
         default: "0.8.3"
-      process_exporter_skip_install:
-        description: "Process exporter installation tasks gets skipped when set to true."
-        type: bool
-        default: false
       process_exporter_binary_local_dir:
         description:
           - "Enables the use of local packages instead of those distributed on github."

--- a/roles/process_exporter/tasks/install.yml
+++ b/roles/process_exporter/tasks/install.yml
@@ -20,7 +20,8 @@
 - name: Get binary
   when:
     - process_exporter_binary_local_dir | length == 0
-    - not process_exporter_skip_install
+  tags:
+    - process_exporter_install
   block:
 
     - name: Download process_exporter binary to local folder
@@ -65,5 +66,6 @@
     group: root
   when:
     - process_exporter_binary_local_dir | length > 0
-    - not process_exporter_skip_install
   notify: restart process_exporter
+  tags:
+    - process_exporter_install

--- a/roles/process_exporter/tasks/preflight.yml
+++ b/roles/process_exporter/tasks/preflight.yml
@@ -20,6 +20,13 @@
   ansible.builtin.package_facts:
   when: "not 'packages' in ansible_facts"
 
+- name: "Check for deprecated skip_install variable"
+  ansible.builtin.assert:
+    that:
+      - process_exporter_skip_install is not defined
+    fail_msg: "The variable 'process_exporter_skip_install' is deprecated.
+               Please use '--skip-tags process_exporter_install' instead to skip the installation."
+
 - name: Naive assertion of proper listen address
   ansible.builtin.assert:
     that:
@@ -52,12 +59,14 @@
   when:
     - process_exporter_version == "latest"
     - process_exporter_binary_local_dir | length == 0
-    - not process_exporter_skip_install
+  tags:
+    - process_exporter_install
 
 - name: Get process_exporter binary checksum
   when:
     - process_exporter_binary_local_dir | length == 0
-    - not process_exporter_skip_install
+  tags:
+    - process_exporter_install
   block:
     - name: Get checksum list from github
       ansible.builtin.set_fact:

--- a/roles/prometheus/defaults/main.yml
+++ b/roles/prometheus/defaults/main.yml
@@ -4,7 +4,6 @@ prometheus_binary_local_dir: ''
 prometheus_binary_url: "https://github.com/{{ _prometheus_repo }}/releases/download/v{{ prometheus_version }}/\
                         prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
 prometheus_checksums_url: "https://github.com/{{ _prometheus_repo }}/releases/download/v{{ prometheus_version }}/sha256sums.txt"
-prometheus_skip_install: false
 
 prometheus_config_dir: /etc/prometheus
 prometheus_db_dir: /var/lib/prometheus

--- a/roles/prometheus/meta/argument_specs.yml
+++ b/roles/prometheus/meta/argument_specs.yml
@@ -13,10 +13,6 @@ argument_specs:
           - "Prometheus package version. Also accepts C(latest) as parameter."
           - "Only prometheus 2.x is supported"
         default: "2.54.1"
-      prometheus_skip_install:
-        description: "Prometheus installation tasks gets skipped when set to true."
-        type: bool
-        default: false
       prometheus_binary_local_dir:
         description:
           - "Allows to use local packages instead of ones distributed on github."

--- a/roles/prometheus/tasks/install.yml
+++ b/roles/prometheus/tasks/install.yml
@@ -38,7 +38,8 @@
 - name: Get prometheus binary
   when:
     - prometheus_binary_local_dir | length == 0
-    - not prometheus_skip_install
+  tags:
+    - prometheus_install
   block:
 
     - name: Download prometheus binary to local folder
@@ -103,9 +104,10 @@
     - promtool
   when:
     - prometheus_binary_local_dir | length > 0
-    - not prometheus_skip_install
   notify:
     - restart prometheus
+  tags:
+    - prometheus_install
 
 - name: Create systemd service unit
   ansible.builtin.template:

--- a/roles/prometheus/tasks/preflight.yml
+++ b/roles/prometheus/tasks/preflight.yml
@@ -20,6 +20,13 @@
   ansible.builtin.package_facts:
   when: "not 'packages' in ansible_facts"
 
+- name: "Check for deprecated skip_install variable"
+  ansible.builtin.assert:
+    that:
+      - prometheus_skip_install is not defined
+    fail_msg: "The variable 'prometheus_skip_install' is deprecated.
+               Please use '--skip-tags prometheus_install' instead to skip the installation."
+
 - name: Assert that used version supports listen address type
   ansible.builtin.assert:
     that:
@@ -99,12 +106,14 @@
   when:
     - prometheus_version == "latest"
     - prometheus_binary_local_dir | length == 0
-    - not prometheus_skip_install
+  tags:
+    - prometheus_install
 
 - name: Get prometheus binary checksum
   when:
     - prometheus_binary_local_dir | length == 0
-    - not prometheus_skip_install
+  tags:
+    - prometheus_install
   block:
     - name: "Get checksum list"
       ansible.builtin.set_fact:

--- a/roles/pushgateway/defaults/main.yml
+++ b/roles/pushgateway/defaults/main.yml
@@ -4,7 +4,6 @@ pushgateway_binary_local_dir: ""
 pushgateway_binary_url: "https://github.com/{{ _pushgateway_repo }}/releases/download/v{{ pushgateway_version }}/\
                            pushgateway-{{ pushgateway_version }}.linux-{{ go_arch }}.tar.gz"
 pushgateway_checksums_url: "https://github.com/{{ _pushgateway_repo }}/releases/download/v{{ pushgateway_version }}/sha256sums.txt"
-pushgateway_skip_install: false
 
 pushgateway_web_listen_address: "0.0.0.0:9091"
 pushgateway_web_telemetry_path: "/metrics"

--- a/roles/pushgateway/meta/argument_specs.yml
+++ b/roles/pushgateway/meta/argument_specs.yml
@@ -11,10 +11,6 @@ argument_specs:
       pushgateway_version:
         description: "Pushgateway package version. Also accepts latest as parameter."
         default: "1.10.0"
-      pushgateway_skip_install:
-        description: "Pushgateway installation tasks gets skipped when set to true."
-        type: bool
-        default: false
       pushgateway_binary_local_dir:
         description:
           - "Enables the use of local packages instead of those distributed on github."

--- a/roles/pushgateway/tasks/install.yml
+++ b/roles/pushgateway/tasks/install.yml
@@ -20,7 +20,8 @@
 - name: Get binary
   when:
     - pushgateway_binary_local_dir | length == 0
-    - not pushgateway_skip_install
+  tags:
+    - pushgateway_install
   block:
 
     - name: Download pushgateway binary to local folder
@@ -65,5 +66,6 @@
     group: root
   when:
     - pushgateway_binary_local_dir | length > 0
-    - not pushgateway_skip_install
   notify: restart pushgateway
+  tags:
+    - pushgateway_install

--- a/roles/pushgateway/tasks/preflight.yml
+++ b/roles/pushgateway/tasks/preflight.yml
@@ -66,6 +66,13 @@
           - "__pushgateway_cert_file.stat.exists"
           - "__pushgateway_key_file.stat.exists"
 
+- name: "Check for deprecated skip_install variable"
+  ansible.builtin.assert:
+    that:
+      - pushgateway_skip_install is not defined
+    fail_msg: "The variable 'pushgateway_skip_install' is deprecated.
+               Please use '--skip-tags pushgateway_install' instead to skip the installation."
+
 - name: Check if pushgateway is installed
   ansible.builtin.stat:
     path: "{{ pushgateway_binary_install_dir }}/pushgateway"
@@ -93,12 +100,14 @@
   when:
     - pushgateway_version == "latest"
     - pushgateway_binary_local_dir | length == 0
-    - not pushgateway_skip_install
+  tags:
+    - pushgateway_install
 
 - name: Get pushgateway binary checksum
   when:
     - pushgateway_binary_local_dir | length == 0
-    - not pushgateway_skip_install
+  tags:
+    - pushgateway_install
   block:
     - name: Get checksum list from github
       ansible.builtin.set_fact:

--- a/roles/redis_exporter/defaults/main.yml
+++ b/roles/redis_exporter/defaults/main.yml
@@ -4,7 +4,6 @@ redis_exporter_binary_local_dir: ""
 redis_exporter_binary_url: "https://github.com/{{ _redis_exporter_repo }}/releases/download/v{{ redis_exporter_version }}/\
                            redis_exporter-v{{ redis_exporter_version }}.linux-{{ go_arch }}.tar.gz"
 redis_exporter_checksums_url: "https://github.com/{{ _redis_exporter_repo }}/releases/download/v{{ redis_exporter_version }}/sha256sums.txt"
-redis_exporter_skip_install: false
 
 # https://github.com/oliver006/redis_exporter?tab=readme-ov-file#command-line-flags
 redis_exporter_addr: "redis://localhost:6379"

--- a/roles/redis_exporter/meta/argument_specs.yml
+++ b/roles/redis_exporter/meta/argument_specs.yml
@@ -11,10 +11,6 @@ argument_specs:
       redis_exporter_version:
         description: "redis_exporter package version. Also accepts latest as parameter."
         default: "1.63.0"
-      redis_exporter_skip_install:
-        description: "redis_exporter installation tasks gets skipped when set to true."
-        type: bool
-        default: false
       redis_exporter_binary_local_dir:
         description:
           - "Enables the use of local packages instead of those distributed on github."

--- a/roles/redis_exporter/tasks/install.yml
+++ b/roles/redis_exporter/tasks/install.yml
@@ -20,7 +20,8 @@
 - name: Get binary
   when:
     - redis_exporter_binary_local_dir | length == 0
-    - not redis_exporter_skip_install
+  tags:
+    - redis_exporter_install
   block:
 
     - name: Download redis_exporter binary to local folder
@@ -65,5 +66,6 @@
     group: root
   when:
     - redis_exporter_binary_local_dir | length > 0
-    - not redis_exporter_skip_install
   notify: restart redis_exporter
+  tags:
+    - redis_exporter_install

--- a/roles/redis_exporter/tasks/preflight.yml
+++ b/roles/redis_exporter/tasks/preflight.yml
@@ -20,6 +20,13 @@
   ansible.builtin.package_facts:
   when: "not 'packages' in ansible_facts"
 
+- name: "Check for deprecated skip_install variable"
+  ansible.builtin.assert:
+    that:
+      - redis_exporter_skip_install is not defined
+    fail_msg: "The variable 'redis_exporter_skip_install' is deprecated.
+               Please use '--skip-tags redis_exporter_install' instead to skip the installation."
+
 - name: Assert that used version supports listen address type
   ansible.builtin.assert:
     that:
@@ -90,12 +97,14 @@
   when:
     - redis_exporter_version == "latest"
     - redis_exporter_binary_local_dir | length == 0
-    - not redis_exporter_skip_install
+  tags:
+    - redis_exporter_install
 
 - name: Get redis_exporter binary checksum
   when:
     - redis_exporter_binary_local_dir | length == 0
-    - not redis_exporter_skip_install
+  tags:
+    - redis_exporter_install
   block:
     - name: Get checksum list from github
       ansible.builtin.set_fact:

--- a/roles/smartctl_exporter/defaults/main.yml
+++ b/roles/smartctl_exporter/defaults/main.yml
@@ -4,7 +4,6 @@ smartctl_exporter_binary_local_dir: ""
 smartctl_exporter_binary_url: "https://github.com/{{ _smartctl_exporter_repo }}/releases/download/v{{ smartctl_exporter_version }}/\
                            smartctl_exporter-{{ smartctl_exporter_version }}.linux-{{ go_arch }}.tar.gz"
 smartctl_exporter_checksums_url: "https://github.com/{{ _smartctl_exporter_repo }}/releases/download/v{{ smartctl_exporter_version }}/sha256sums.txt"
-smartctl_exporter_skip_install: false
 
 smartctl_exporter_smartctl_path: "/usr/sbin/smartctl"
 smartctl_exporter_smartctl_interval: "60s"

--- a/roles/smartctl_exporter/meta/argument_specs.yml
+++ b/roles/smartctl_exporter/meta/argument_specs.yml
@@ -11,10 +11,6 @@ argument_specs:
       smartctl_exporter_version:
         description: "Smartctl exporter package version. Also accepts latest as parameter."
         default: "0.12.0"
-      smartctl_exporter_skip_install:
-        description: "Smartctl exporter installation tasks gets skipped when set to true."
-        type: bool
-        default: false
       smartctl_exporter_binary_local_dir:
         description:
           - "Enables the use of local packages instead of those distributed on github."

--- a/roles/smartctl_exporter/tasks/install.yml
+++ b/roles/smartctl_exporter/tasks/install.yml
@@ -20,7 +20,8 @@
 - name: Get binary
   when:
     - smartctl_exporter_binary_local_dir | length == 0
-    - not smartctl_exporter_skip_install
+  tags:
+    - smartctl_exporter_install
   block:
 
     - name: Download smartctl_exporter binary to local folder
@@ -65,5 +66,6 @@
     group: root
   when:
     - smartctl_exporter_binary_local_dir | length > 0
-    - not smartctl_exporter_skip_install
   notify: restart smartctl_exporter
+  tags:
+    - smartctl_exporter_install

--- a/roles/smartctl_exporter/tasks/preflight.yml
+++ b/roles/smartctl_exporter/tasks/preflight.yml
@@ -61,6 +61,13 @@
           - "__smartctl_exporter_cert_file.stat.exists"
           - "__smartctl_exporter_key_file.stat.exists"
 
+- name: "Check for deprecated skip_install variable"
+  ansible.builtin.assert:
+    that:
+      - smartctl_exporter_skip_install is not defined
+    fail_msg: "The variable 'smartctl_exporter_skip_install' is deprecated.
+               Please use '--skip-tags smartctl_exporter_install' instead to skip the installation."
+
 - name: Check if smartctl_exporter is installed
   ansible.builtin.stat:
     path: "{{ smartctl_exporter_binary_install_dir }}/smartctl_exporter"
@@ -88,12 +95,14 @@
   when:
     - smartctl_exporter_version == "latest"
     - smartctl_exporter_binary_local_dir | length == 0
-    - not smartctl_exporter_skip_install
+  tags:
+    - smartctl_exporter_install
 
 - name: Get smartctl_exporter binary checksum
   when:
     - smartctl_exporter_binary_local_dir | length == 0
-    - not smartctl_exporter_skip_install
+  tags:
+    - smartctl_exporter_install
   block:
     - name: Get checksum list from github
       ansible.builtin.set_fact:

--- a/roles/smokeping_prober/defaults/main.yml
+++ b/roles/smokeping_prober/defaults/main.yml
@@ -4,7 +4,6 @@ smokeping_prober_binary_local_dir: ""
 smokeping_prober_binary_url: "https://github.com/{{ _smokeping_prober_repo }}/releases/download/v{{ smokeping_prober_version }}/\
                            smokeping_prober-{{ smokeping_prober_version }}.linux-{{ go_arch }}.tar.gz"
 smokeping_prober_checksums_url: "https://github.com/{{ _smokeping_prober_repo }}/releases/download/v{{ smokeping_prober_version }}/sha256sums.txt"
-smokeping_prober_skip_install: false
 
 smokeping_prober_web_listen_address: "0.0.0.0:9374"
 

--- a/roles/smokeping_prober/meta/argument_specs.yml
+++ b/roles/smokeping_prober/meta/argument_specs.yml
@@ -11,10 +11,6 @@ argument_specs:
       smokeping_prober_version:
         description: "Smokeping Prober package version. Also accepts latest as parameter."
         default: "0.8.1"
-      smokeping_prober_skip_install:
-        description: "Smokeping Prober installation tasks gets skipped when set to true."
-        type: bool
-        default: false
       smokeping_prober_binary_local_dir:
         description:
           - "Enables the use of local packages instead of those distributed on github."

--- a/roles/smokeping_prober/tasks/install.yml
+++ b/roles/smokeping_prober/tasks/install.yml
@@ -20,7 +20,8 @@
 - name: Get binary
   when:
     - smokeping_prober_binary_local_dir | length == 0
-    - not smokeping_prober_skip_install
+  tags:
+    - smokeping_prober_install
   block:
 
     - name: Download smokeping_prober binary to local folder
@@ -65,5 +66,6 @@
     group: root
   when:
     - smokeping_prober_binary_local_dir | length > 0
-    - not smokeping_prober_skip_install
   notify: restart smokeping_prober
+  tags:
+    - smokeping_prober_install

--- a/roles/smokeping_prober/tasks/preflight.yml
+++ b/roles/smokeping_prober/tasks/preflight.yml
@@ -66,6 +66,13 @@
           - "__smokeping_prober_cert_file.stat.exists"
           - "__smokeping_prober_key_file.stat.exists"
 
+- name: "Check for deprecated skip_install variable"
+  ansible.builtin.assert:
+    that:
+      - smokeping_prober_skip_install is not defined
+    fail_msg: "The variable 'smokeping_prober_skip_install' is deprecated.
+               Please use '--skip-tags smokeping_prober_install' instead to skip the installation."
+
 - name: Check if smokeping_prober is installed
   ansible.builtin.stat:
     path: "{{ smokeping_prober_binary_install_dir }}/smokeping_prober"
@@ -93,12 +100,14 @@
   when:
     - smokeping_prober_version == "latest"
     - smokeping_prober_binary_local_dir | length == 0
-    - not smokeping_prober_skip_install
+  tags:
+    - smokeping_prober_install
 
 - name: Get smokeping_prober binary checksum
   when:
     - smokeping_prober_binary_local_dir | length == 0
-    - not smokeping_prober_skip_install
+  tags:
+    - smokeping_prober_install
   block:
     - name: Get checksum list from github
       ansible.builtin.set_fact:

--- a/roles/snmp_exporter/defaults/main.yml
+++ b/roles/snmp_exporter/defaults/main.yml
@@ -4,7 +4,6 @@ snmp_exporter_binary_local_dir: ""
 snmp_exporter_binary_url: "https://github.com/{{ _snmp_exporter_repo }}/releases/download/v{{ snmp_exporter_version }}/\
                            snmp_exporter-{{ snmp_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
 snmp_exporter_checksums_url: "https://github.com/{{ _snmp_exporter_repo }}/releases/download/v{{ snmp_exporter_version }}/sha256sums.txt"
-snmp_exporter_skip_install: false
 snmp_exporter_web_listen_address: "0.0.0.0:9116"
 snmp_exporter_log_level: info
 

--- a/roles/snmp_exporter/meta/argument_specs.yml
+++ b/roles/snmp_exporter/meta/argument_specs.yml
@@ -11,10 +11,6 @@ argument_specs:
       snmp_exporter_version:
         description: "SNMP exporter package version. Also accepts latest as parameter."
         default: "0.26.0"
-      snmp_exporter_skip_install:
-        description: "SNMP exporter installation tasks gets skipped when set to true."
-        type: bool
-        default: false
       snmp_exporter_binary_local_dir:
         description:
           - "Enables the use of local packages instead of those distributed on github."

--- a/roles/snmp_exporter/tasks/install.yml
+++ b/roles/snmp_exporter/tasks/install.yml
@@ -2,7 +2,8 @@
 - name: Get binary
   when:
     - snmp_exporter_binary_local_dir | length == 0
-    - not snmp_exporter_skip_install
+  tags:
+    - snmp_exporter_install
   block:
 
     - name: Download snmp_exporter binary to local folder
@@ -47,5 +48,6 @@
     group: root
   when:
     - snmp_exporter_binary_local_dir | length > 0
-    - not snmp_exporter_skip_install
   notify: restart snmp_exporter
+  tags:
+    - snmp_exporter_install

--- a/roles/snmp_exporter/tasks/preflight.yml
+++ b/roles/snmp_exporter/tasks/preflight.yml
@@ -21,6 +21,13 @@
           list |
           length == 0
 
+- name: "Check for deprecated skip_install variable"
+  ansible.builtin.assert:
+    that:
+      - snmp_exporter_skip_install is not defined
+    fail_msg: "The variable 'snmp_exporter_skip_install' is deprecated.
+               Please use '--skip-tags snmp_exporter_install' instead to skip the installation."
+
 - name: Discover latest version
   ansible.builtin.set_fact:
     snmp_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _snmp_exporter_repo }}/releases/latest', headers=_github_api_headers,
@@ -31,12 +38,14 @@
   when:
     - snmp_exporter_version == "latest"
     - snmp_exporter_binary_local_dir | length == 0
-    - not snmp_exporter_skip_install
+  tags:
+    - smartctl_exporter_install
 
 - name: Get snmp_exporter binary checksum
   when:
     - snmp_exporter_binary_local_dir | length == 0
-    - not snmp_exporter_skip_install
+  tags:
+    - smartctl_exporter_install
   block:
     - name: Get checksum list from github
       ansible.builtin.set_fact:

--- a/roles/systemd_exporter/defaults/main.yml
+++ b/roles/systemd_exporter/defaults/main.yml
@@ -4,7 +4,6 @@ systemd_exporter_binary_local_dir: ""
 systemd_exporter_binary_url: "https://github.com/{{ _systemd_exporter_repo }}/releases/download/v{{ systemd_exporter_version }}/\
                                     systemd_exporter-{{ systemd_exporter_version }}.linux-{{ go_arch }}.tar.gz"
 systemd_exporter_checksums_url: "https://github.com/{{ _systemd_exporter_repo }}/releases/download/v{{ systemd_exporter_version }}/sha256sums.txt"
-systemd_exporter_skip_install: false
 systemd_exporter_web_listen_address: "0.0.0.0:9558"
 
 systemd_exporter_tls_server_config: {}

--- a/roles/systemd_exporter/meta/argument_specs.yml
+++ b/roles/systemd_exporter/meta/argument_specs.yml
@@ -11,10 +11,6 @@ argument_specs:
       systemd_exporter_version:
         description: "SystemD exporter package version. Also accepts latest as parameter."
         default: "0.6.0"
-      systemd_exporter_skip_install:
-        description: "SystemD exporter installation tasks gets skipped when set to true."
-        type: bool
-        default: false
       systemd_exporter_binary_local_dir:
         description:
           - "Allows to use local packages instead of ones distributed on github."

--- a/roles/systemd_exporter/tasks/install.yml
+++ b/roles/systemd_exporter/tasks/install.yml
@@ -20,7 +20,8 @@
 - name: Get systemd exporter binary
   when:
     - systemd_exporter_binary_local_dir | length == 0
-    - not systemd_exporter_skip_install
+  tags:
+    - systemd_exporter_install
   block:
     - name: Download systemd_exporter binary to local folder
       become: false
@@ -64,5 +65,6 @@
     group: root
   when:
     - systemd_exporter_binary_local_dir | length > 0
-    - not systemd_exporter_skip_install
   notify: restart systemd_exporter
+  tags:
+    - systemd_exporter_install

--- a/roles/systemd_exporter/tasks/preflight.yml
+++ b/roles/systemd_exporter/tasks/preflight.yml
@@ -78,6 +78,13 @@
     systemd_exporter_system_user: "root"
   when: systemd_exporter_enable_file_descriptor_size
 
+- name: "Check for deprecated skip_install variable"
+  ansible.builtin.assert:
+    that:
+      - systemd_exporter_skip_install is not defined
+    fail_msg: "The variable 'systemd_exporter_skip_install' is deprecated.
+               Please use '--skip-tags systemd_exporter_install' instead to skip the installation."
+
 - name: Check if systemd_exporter is installed
   ansible.builtin.stat:
     path: "{{ systemd_exporter_binary_install_dir }}/systemd_exporter"
@@ -87,14 +94,14 @@
     - systemd_exporter_install
 
 - name: Gather currently installed systemd_exporter version (if any)
-  command: "{{ systemd_exporter_binary_install_dir }}/systemd_exporter --version"
+  ansible.builtin.command:
+    cmd: "{{ systemd_exporter_binary_install_dir }}/systemd_exporter --version"
   changed_when: false
   register: __systemd_exporter_current_version_output
   check_mode: false
   when: __systemd_exporter_is_installed.stat.exists
   tags:
     - systemd_exporter_install
-    - skip_ansible_lint
 
 - name: Discover latest version
   ansible.builtin.set_fact:
@@ -106,12 +113,14 @@
   when:
     - systemd_exporter_version == "latest"
     - systemd_exporter_binary_local_dir | length == 0
-    - not systemd_exporter_skip_install
+  tags:
+    - systemd_exporter_install
 
 - name: Get systemd exporter binary checksum
   when:
     - systemd_exporter_binary_local_dir | length == 0
-    - not systemd_exporter_skip_install
+  tags:
+    - systemd_exporter_install
   block:
     - name: Get checksum list from github
       ansible.builtin.set_fact:


### PR DESCRIPTION
Using a variable to skip installation is redundant because the same result can be achieved with tags. Tags already provide the flexibility to skip the installation or other sections of the roles, such as configuration tasks.