### PR TITLE
removed: CentOS Stream and Fedora from being officially supported

### DIFF
--- a/.config/molecule/config.yml
+++ b/.config/molecule/config.yml
@@ -17,12 +17,6 @@ platforms:
     privileged: true
     cgroup_parent: docker.slice
     command: /lib/systemd/systemd
-  - name: centos-stream-9
-    image: dokken/centos-stream-9
-    pre_build_image: true
-    privileged: true
-    cgroup_parent: docker.slice
-    command: /lib/systemd/systemd
   - name: debian-11
     image: dokken/debian-11
     pre_build_image: true

--- a/.config/molecule/config.yml
+++ b/.config/molecule/config.yml
@@ -23,18 +23,6 @@ platforms:
     privileged: true
     cgroup_parent: docker.slice
     command: /lib/systemd/systemd
-  - name: fedora-39
-    image: dokken/fedora-39
-    pre_build_image: true
-    privileged: true
-    cgroup_parent: docker.slice
-    command: /lib/systemd/systemd
-  - name: fedora-40
-    image: dokken/fedora-40
-    pre_build_image: true
-    privileged: true
-    cgroup_parent: docker.slice
-    command: /lib/systemd/systemd
   - name: ubuntu-20.04
     image: dokken/ubuntu-20.04
     pre_build_image: true
@@ -67,21 +55,11 @@ provisioner:
       target_hosts:
         hosts: {}
     host_vars:
-      fedora-39:
+      almalinux-8:
         exclude_ansible_vers:
-          - "2.9"
-          - "2.10"
-          - "2.11"
-      fedora-40:
-        exclude_ansible_vers:
-          - "2.9"
-          - "2.10"
-          - "2.11"
+          - "2.17"
       ubuntu-24.04:
         exclude_ansible_vers:
           - "2.9"
           - "2.10"
           - "2.11"
-      almalinux-8:
-        exclude_ansible_vers:
-          - "2.17"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,4 +93,4 @@ To accomplish this all roles need to support:
 
 - current and at least one previous ansible version
 - systemd as the only available process manager
-- at least latest debian and CentOS distributions
+- at least latest Debian/Ubuntu and EL distributions

--- a/roles/alertmanager/meta/main.yml
+++ b/roles/alertmanager/meta/main.yml
@@ -17,10 +17,6 @@ galaxy_info:
       versions:
         - "8"
         - "9"
-    - name: "Fedora"
-      versions:
-        - "39"
-        - "40"
   galaxy_tags:
     - "monitoring"
     - "prometheus"

--- a/roles/bind_exporter/meta/main.yml
+++ b/roles/bind_exporter/meta/main.yml
@@ -17,10 +17,6 @@ galaxy_info:
       versions:
         - "8"
         - "9"
-    - name: "Fedora"
-      versions:
-        - "39"
-        - "40"
   galaxy_tags:
     - "monitoring"
     - "prometheus"

--- a/roles/blackbox_exporter/meta/main.yml
+++ b/roles/blackbox_exporter/meta/main.yml
@@ -17,10 +17,6 @@ galaxy_info:
       versions:
         - "8"
         - "9"
-    - name: "Fedora"
-      versions:
-        - "39"
-        - "40"
   galaxy_tags:
     - "exporter"
     - "monitoring"

--- a/roles/cadvisor/meta/main.yml
+++ b/roles/cadvisor/meta/main.yml
@@ -17,10 +17,6 @@ galaxy_info:
       versions:
         - "8"
         - "9"
-    - name: "Fedora"
-      versions:
-        - "39"
-        - "40"
   galaxy_tags:
     - "monitoring"
     - "prometheus"

--- a/roles/chrony_exporter/meta/main.yml
+++ b/roles/chrony_exporter/meta/main.yml
@@ -17,10 +17,6 @@ galaxy_info:
       versions:
         - "8"
         - "9"
-    - name: "Fedora"
-      versions:
-        - "39"
-        - "40"
   galaxy_tags:
     - "monitoring"
     - "prometheus"

--- a/roles/fail2ban_exporter/meta/main.yml
+++ b/roles/fail2ban_exporter/meta/main.yml
@@ -17,10 +17,6 @@ galaxy_info:
       versions:
         - "8"
         - "9"
-    - name: "Fedora"
-      versions:
-        - "39"
-        - "40"
   galaxy_tags:
     - "monitoring"
     - "prometheus"

--- a/roles/ipmi_exporter/meta/main.yml
+++ b/roles/ipmi_exporter/meta/main.yml
@@ -17,10 +17,6 @@ galaxy_info:
       versions:
         - "8"
         - "9"
-    - name: "Fedora"
-      versions:
-        - "39"
-        - "40"
   galaxy_tags:
     - "monitoring"
     - "prometheus"

--- a/roles/memcached_exporter/meta/main.yml
+++ b/roles/memcached_exporter/meta/main.yml
@@ -17,10 +17,6 @@ galaxy_info:
       versions:
         - "8"
         - "9"
-    - name: "Fedora"
-      versions:
-        - "39"
-        - "40"
   galaxy_tags:
     - "monitoring"
     - "prometheus"

--- a/roles/mongodb_exporter/meta/main.yml
+++ b/roles/mongodb_exporter/meta/main.yml
@@ -17,10 +17,6 @@ galaxy_info:
       versions:
         - "8"
         - "9"
-    - name: "Fedora"
-      versions:
-        - "39"
-        - "40"
   galaxy_tags:
     - "monitoring"
     - "prometheus"

--- a/roles/mysqld_exporter/meta/main.yml
+++ b/roles/mysqld_exporter/meta/main.yml
@@ -17,10 +17,6 @@ galaxy_info:
       versions:
         - "8"
         - "9"
-    - name: "Fedora"
-      versions:
-        - "39"
-        - "40"
   galaxy_tags:
     - "monitoring"
     - "prometheus"

--- a/roles/nginx_exporter/meta/main.yml
+++ b/roles/nginx_exporter/meta/main.yml
@@ -17,10 +17,6 @@ galaxy_info:
       versions:
         - "8"
         - "9"
-    - name: "Fedora"
-      versions:
-        - "39"
-        - "40"
   galaxy_tags:
     - "monitoring"
     - "prometheus"

--- a/roles/node_exporter/meta/main.yml
+++ b/roles/node_exporter/meta/main.yml
@@ -17,10 +17,6 @@ galaxy_info:
       versions:
         - "8"
         - "9"
-    - name: "Fedora"
-      versions:
-        - "39"
-        - "40"
   galaxy_tags:
     - "monitoring"
     - "prometheus"

--- a/roles/postgres_exporter/meta/main.yml
+++ b/roles/postgres_exporter/meta/main.yml
@@ -17,10 +17,6 @@ galaxy_info:
       versions:
         - "8"
         - "9"
-    - name: "Fedora"
-      versions:
-        - "39"
-        - "40"
   galaxy_tags:
     - "monitoring"
     - "prometheus"

--- a/roles/process_exporter/meta/main.yml
+++ b/roles/process_exporter/meta/main.yml
@@ -17,10 +17,6 @@ galaxy_info:
       versions:
         - "8"
         - "9"
-    - name: "Fedora"
-      versions:
-        - "39"
-        - "40"
   galaxy_tags:
     - "monitoring"
     - "prometheus"

--- a/roles/prometheus/meta/main.yml
+++ b/roles/prometheus/meta/main.yml
@@ -17,10 +17,6 @@ galaxy_info:
       versions:
         - "8"
         - "9"
-    - name: "Fedora"
-      versions:
-        - "39"
-        - "40"
   galaxy_tags:
     - "monitoring"
     - "prometheus"

--- a/roles/pushgateway/meta/main.yml
+++ b/roles/pushgateway/meta/main.yml
@@ -17,10 +17,6 @@ galaxy_info:
       versions:
         - "8"
         - "9"
-    - name: "Fedora"
-      versions:
-        - "39"
-        - "40"
   galaxy_tags:
     - "monitoring"
     - "prometheus"

--- a/roles/redis_exporter/meta/main.yml
+++ b/roles/redis_exporter/meta/main.yml
@@ -17,10 +17,6 @@ galaxy_info:
       versions:
         - "8"
         - "9"
-    - name: "Fedora"
-      versions:
-        - "39"
-        - "40"
   galaxy_tags:
     - "monitoring"
     - "prometheus"

--- a/roles/smartctl_exporter/meta/main.yml
+++ b/roles/smartctl_exporter/meta/main.yml
@@ -17,10 +17,6 @@ galaxy_info:
       versions:
         - "8"
         - "9"
-    - name: "Fedora"
-      versions:
-        - "39"
-        - "40"
   galaxy_tags:
     - "monitoring"
     - "prometheus"

--- a/roles/smokeping_prober/meta/main.yml
+++ b/roles/smokeping_prober/meta/main.yml
@@ -17,10 +17,6 @@ galaxy_info:
       versions:
         - "8"
         - "9"
-    - name: "Fedora"
-      versions:
-        - "39"
-        - "40"
   galaxy_tags:
     - "monitoring"
     - "prometheus"

--- a/roles/snmp_exporter/meta/main.yml
+++ b/roles/snmp_exporter/meta/main.yml
@@ -17,10 +17,6 @@ galaxy_info:
       versions:
         - "8"
         - "9"
-    - name: "Fedora"
-      versions:
-        - "39"
-        - "40"
   galaxy_tags:
     - "monitoring"
     - "prometheus"

--- a/roles/systemd_exporter/meta/main.yml
+++ b/roles/systemd_exporter/meta/main.yml
@@ -18,10 +18,6 @@ galaxy_info:
       versions:
         - "8"
         - "9"
-    - name: "Fedora"
-      versions:
-        - "39"
-        - "40"
   galaxy_tags:
     - "monitoring"
     - "prometheus"


### PR DESCRIPTION
Removed CentOS Stream and Fedora from being officially supported.

- CentOS Stream should still work as we are running tests on AlmaLinux.
- Fedora isn't widely used as a server distro

This should trim down our CI test count/time a bit.