### PR TITLE
fix: mark download tasks as unchanged

### DIFF
--- a/roles/_common/tasks/install.yml
+++ b/roles/_common/tasks/install.yml
@@ -53,6 +53,7 @@
     mode: 0755
   delegate_to: localhost
   check_mode: false
+  changed_when: false
   tags:
     - "{{ ansible_parent_role_names | first | regex_replace(ansible_collection_name ~ '.', '') }}"
     - install
@@ -90,6 +91,7 @@
       # run_once: true  # <-- this can't be set due to multi-arch support
       delegate_to: localhost
       check_mode: false
+      changed_when: false
 
     - name: "Unpack binary archive {{ __common_binary_basename }}"
       ansible.builtin.unarchive:
@@ -101,6 +103,7 @@
       register: __common_unpack
       delegate_to: localhost
       check_mode: false
+      changed_when: false
       when: __common_binary_basename is search('\.zip$|\.tar\.gz$')
 
 - name: "Propagate binaries"


### PR DESCRIPTION
# Summary

This PR suggests changing the behavior of the tasks downloading the binaries following the discussions on !431.

The main arguments for this are:
- the tasks are executed locally, they do not affect the remote host, therefore having them mark the remote host as `changed` is unnecessarily confusing
- the tasks are prerequisites for the role anyway, you expect them to download something because it wouldn't make sense otherwise
- only the first host in the host loop will be `changed` because of that, which only adds to the confusion
- the task which we really care about to tell whether the remote host was changed or not is the `Propagate binaries` task
- it's not always possible to preserve the `_common_local_cache_path` folder between ansible runs: if I deploy an exporter on a host I expect to see no `changed` if I re-run the role several weeks later. 

The main arguments against this are:
- you should be able to see when the download is actually being executed, and `changed_when: false` hides that completely
- this is a non-issue if you should properly cache `_common_local_cache_path` between runs to avoid repeated download requests

I'm of course biased towards the arguments in favor of this change, please feel free to argue against it!