### PR TITLE
fix(blackbox_exporter): make capability setting idempotent

### DIFF
--- a/roles/blackbox_exporter/tasks/configure.yml
+++ b/roles/blackbox_exporter/tasks/configure.yml
@@ -15,11 +15,10 @@
 - name: Ensure blackbox exporter binary has cap_net_raw capability
   community.general.capabilities:
     path: "{{ blackbox_exporter_binary_install_dir }}/blackbox_exporter"
-    capability: cap_net_raw+ep
+    capability: cap_net_raw=ep
     state: present
   become: true
   when: not ansible_check_mode
-  changed_when: "'molecule-idempotence-notest' not in ansible_skip_tags"
   tags:
     - blackbox_exporter
     - configure

--- a/roles/blackbox_exporter/tasks/configure.yml
+++ b/roles/blackbox_exporter/tasks/configure.yml
@@ -23,6 +23,7 @@
     - blackbox_exporter
     - configure
     - blackbox_exporter_configure
+    - molecule-idempotence-notest
 
 - name: Check Debug Message
   ansible.builtin.debug:


### PR DESCRIPTION
Recently, the "Ensure blackbox exporter binary has cap_net_raw capability" task has reported a change for every pipeline run. This PR contains two changes to fix this behavior.

* An [old bug](https://github.com/ansible-collections/community.general/issues/4067) in `community.general.capabilities`, which is caused by naive comparison between requested state and observed state, will indicate a change if the operation is anything besides `=`. This PR changes from `cap_net_raw+ep` to `cap_net_raw=ep` to fix this.

* A [recent PR](https://github.com/prometheus-community/ansible/blob/main/roles/blackbox_exporter/tasks/configure.yml#L22) set `changed_when: "'molecule-idempotence-notest' not in ansible_skip_tags"`, which translates to `changed_when: true`, causing this task to appear as changed no matter what. This PR removes this line.

With these changes, our pipeline reports no change if the `cap_net_raw` is as wanted, and reports change otherwise.