### PR TITLE
skip_changelog(ci): pin docker collection on old ansible versions

### DIFF
--- a/tests/integration/molecule.sh
+++ b/tests/integration/molecule.sh
@@ -27,18 +27,24 @@ if [ "$(printf '%s\n' "2.12" "$ansible_version" | sort -V | head -n1)" = "2.12" 
        ansible-galaxy collection install -r "$collection_root/requirements.yml"
 elif [ "$(printf '%s\n' "2.10" "$ansible_version" | sort -V | head -n1)" = "2.10" ]; then
        python -m pip install molecule molecule-docker
-       ansible-galaxy collection install git+https://github.com/ansible-collections/community.docker.git
+       ansible-galaxy collection install git+https://github.com/ansible-collections/community.docker.git,stable-3
        ansible-galaxy collection install -r "$collection_root/requirements.yml"
 else
        python -m pip install molecule molecule-docker
        req_dir=$(mktemp -d)
-       requirements="$(awk '/name:/ {print $3}' < "$collection_root/requirements.yml") https://github.com/ansible-collections/community.docker.git"
+       requirements="$(awk '/name:/ {print $3}' < "$collection_root/requirements.yml") https://github.com/ansible-collections/community.docker.git,stable-3"
        for req in $requirements; do
-	       git -C "$req_dir" clone --single-branch --depth 1 "$req"
-	       req="${req##*/}"
-	       req="${req%.*}"
-	       ansible-galaxy collection build "$req_dir/$req" --output-path "$req_dir"
-	       ansible-galaxy collection install "$req_dir/${req//./-}"-*.tar.gz
+               if [[ "$req" == *","* ]]; then
+                       branch="${req##*,}"
+                       req="${req%,*}"
+                       git -C "$req_dir" clone --branch "$branch" --single-branch --depth 1 "$req"
+               else
+                       git -C "$req_dir" clone --single-branch --depth 1 "$req"
+               fi
+               req="${req##*/}"
+               req="${req%.*}"
+               ansible-galaxy collection build "$req_dir/$req" --output-path "$req_dir"
+               ansible-galaxy collection install "$req_dir/${req//./-}"-*.tar.gz
        done
 fi
 


### PR DESCRIPTION
Should fix failing molecule tests on ansible versions 2.9, 2.10, 2.11