### PR TITLE
bugfix: update default home directory

### DIFF
--- a/roles/_common/tasks/install.yml
+++ b/roles/_common/tasks/install.yml
@@ -37,7 +37,7 @@
     system: true
     shell: "/usr/sbin/nologin"
     group: "{{ _common_system_group }}"
-    home: "{{ _common_config_dir | default('/') | ternary(_common_config_dir, '/') }}"
+    home: "{{ _common_config_dir | default('/', true) }}"
     create_home: false
   become: true
   when: _common_system_user not in ansible_facts.getent_passwd

--- a/roles/_common/tasks/install.yml
+++ b/roles/_common/tasks/install.yml
@@ -37,7 +37,7 @@
     system: true
     shell: "/usr/sbin/nologin"
     group: "{{ _common_system_group }}"
-    home: "{{ _common_config_dir | default('/') }}"
+    home: "{{ _common_config_dir | default('/') | ternary(_common_config_dir, '/') }}"
     create_home: false
   become: true
   when: _common_system_user not in ansible_facts.getent_passwd


### PR DESCRIPTION
If there is no customized `_common_config_dir` defined, it will raise an error, `FAILED! => {"changed": false, "msg": "useradd: invalid home directory ''\n", "name": "foo", "rc": 3}`.


Here is an Minimal reproducible example

### Playbook

```yaml
- hosts: ubuntu
  become: true
  vars:
    _common_system_user: foo
    _common_system_group: foo
    _common_config_dir: ""

  tasks:
    - name: "Create system group {{ _common_system_group }}"
      ansible.builtin.group:
        name: "{{ _common_system_group }}"
        system: true
        state: present
      become: true

    - name: "Create system user {{ _common_system_user }}"
      ansible.builtin.user:
        name: "{{ _common_system_user }}"
        system: true
        shell: "/usr/sbin/nologin"
        group: "{{ _common_system_group }}"
        home: "{{ _common_config_dir | default('/') }}"
        create_home: false
      become: true

```

### Result
```shell
❯ ansible-playbook -i invenotory.yaml test.yaml
PLAY [ubuntu] ***************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ****************************************************************************************************************************************************************************************************
ok: [ubuntu]

TASK [Create system group foo] ********************************************************************************************************************************************************************************************
ok: [ubuntu]

TASK [Create system user foo] *********************************************************************************************************************************************************************************************
fatal: [ubuntu]: FAILED! => {"changed": false, "msg": "useradd: invalid home directory ''\n", "name": "foo", "rc": 3}

PLAY RECAP ****************************************************************************************************************************************************************************************************************
ubuntu          : ok=2    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```