### PR TITLE
feat: Support Prometheus 3.0

### DIFF
--- a/roles/prometheus/defaults/main.yml
+++ b/roles/prometheus/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-prometheus_version: 2.54.1
+prometheus_version: 3.0.0
 prometheus_binary_url: "https://github.com/{{ _prometheus_repo }}/releases/download/v{{ prometheus_version }}/\
                         prometheus-{{ prometheus_version }}.{{ ansible_system | lower }}-{{ _prometheus_go_ansible_arch }}.tar.gz"
 prometheus_checksums_url: "https://github.com/{{ _prometheus_repo }}/releases/download/v{{ prometheus_version }}/sha256sums.txt"

--- a/roles/prometheus/meta/argument_specs.yml
+++ b/roles/prometheus/meta/argument_specs.yml
@@ -11,8 +11,8 @@ argument_specs:
       prometheus_version:
         description:
           - "Prometheus package version. Also accepts C(latest) as parameter."
-          - "Only prometheus 2.x is supported"
-        default: "2.54.1"
+          - "Prometheus >= 2.x is supported"
+        default: "3.0.0"
       prometheus_binary_url:
         description: "URL of the prometheus binaries .tar.gz file"
         default: "https://github.com/{{ _prometheus_repo }}/releases/download/v{{ prometheus_version }}/prometheus-{{ prometheus_version }}.{{ ansible_system | lower }}-{{ _prometheus_go_ansible_arch }}.tar.gz"

--- a/roles/prometheus/molecule/agentmode/tests/test_agentmode.py
+++ b/roles/prometheus/molecule/agentmode/tests/test_agentmode.py
@@ -18,7 +18,7 @@ def AnsibleDefaults():
     ("/etc/systemd/system/prometheus.service",
      "storage.agent.path=/var/lib/prometheus"),
     ("/etc/systemd/system/prometheus.service",
-     "enable-feature=agent"),
+     "agent"),
 ])
 def test_file_contents(host, file, content):
     f = host.file(file)

--- a/roles/prometheus/molecule/default/tests/test_default.py
+++ b/roles/prometheus/molecule/default/tests/test_default.py
@@ -37,8 +37,6 @@ def test_directories(host, dirs):
     "files",
     [
         "/etc/prometheus/prometheus.yml",
-        "/etc/prometheus/console_libraries/prom.lib",
-        "/etc/prometheus/consoles/prometheus.html",
         "/etc/prometheus/scrape_configs/empty_scrapes.yml",
         "/etc/systemd/system/prometheus.service",
         "/usr/local/bin/prometheus",

--- a/roles/prometheus/tasks/configure.yml
+++ b/roles/prometheus/tasks/configure.yml
@@ -36,6 +36,8 @@
     group: "{{ prometheus_system_group }}"
     mode: 0775
   loop:
+    - "{{ prometheus_config_dir }}/consoles"
+    - "{{ prometheus_config_dir }}/console_libraries"
     - "{{ prometheus_config_dir }}/rules"
     - "{{ prometheus_config_dir }}/file_sd"
     - "{{ prometheus_config_dir }}/scrape_configs"
@@ -58,6 +60,7 @@
   notify:
     - restart prometheus
   become: true
+  when: prometheus_version is version('3.0.0', '<')
   tags:
     - prometheus
     - configure

--- a/roles/prometheus/templates/prometheus.service.j2
+++ b/roles/prometheus/templates/prometheus.service.j2
@@ -22,7 +22,11 @@ ExecStart={{ prometheus_binary_install_dir }}/prometheus \
   --storage.tsdb.retention={{ prometheus_storage_retention }} \
 {% endif %}
 {% else %}
+{% if prometheus_version is version('3.0.0', '>=') %}
+  --agent \
+{% else %}
   --enable-feature=agent \
+{% endif %}
   --storage.agent.path={{ prometheus_db_dir }} \
 {% endif %}
 {% if (prometheus_version is version('2.24.0', '>=')) and (prometheus_web_config.values() | map('length') | select('gt', 0) | list is any) %}


### PR DESCRIPTION
Update prometheus role for 3.0.0.
* Update argument_specs.yml to reflect support of 3.x.
* Skip console templates on 3.x.

Fixes: https://github.com/prometheus-community/ansible/issues/460