### PR TITLE
fix: Use lookup for console template test

### DIFF
--- a/roles/prometheus/tasks/configure.yml
+++ b/roles/prometheus/tasks/configure.yml
@@ -60,7 +60,7 @@
   notify:
     - restart prometheus
   become: true
-  when: prometheus_version is version('3.0.0', '<')
+  when: "lookup('ansible.builtin.fileglob', {{ prometheus_local_cache_path }}/consoles) != []"
   tags:
     - prometheus
     - configure


### PR DESCRIPTION
When deploying the console templates, use a local lookup to check if the Prometheus tarball contains consoles to deploy.