### PR TITLE
fix: use with_fileglob for iterating over custom alerting rule files

### DIFF
--- a/roles/prometheus/tasks/configure.yml
+++ b/roles/prometheus/tasks/configure.yml
@@ -93,7 +93,7 @@
     group: "{{ prometheus_system_group }}"
     mode: 0640
     validate: "{{ prometheus_binary_install_dir }}/promtool check rules %s"
-  loop: "{{ prometheus_alert_rules_files | map('ansible.builtin.fileglob') | flatten }}"
+  with_fileglob: "{{ prometheus_alert_rules_files }}"
   when:
     - not prometheus_agent_mode
   notify:


### PR DESCRIPTION
Fixes https://github.com/prometheus-community/ansible/issues/484