### PR TITLE
fix: use throttle: 1 for localhost unarchive

### DIFF
--- a/roles/_common/tasks/install.yml
+++ b/roles/_common/tasks/install.yml
@@ -118,6 +118,7 @@
         list_files: true
         extra_opts: "{{ _common_binary_unarchive_opts | default(omit, true) }}"
       check_mode: false
+      throttle: 1  # see prometheus-community/ansible#457
       when: __common_binary_basename is search('\.zip$|\.tar\.gz$')
 
 - name: "Check existence of binary install dir"


### PR DESCRIPTION
During the common install tasks, we download and unpack the binary to install on localhost and eventually upload it to each host (among many other things). Currently the "unpack" step, which extracts the gzipped tar archive, is perform N times if there are N hosts in the inventory, but the target directory (something like
/tmp/node_exporter-linux-arm64/1.8.2) is the same for every host with the same architecture.

This means that all the unarchive tasks are extracting in parallel in an unsynchronized manner to the same directory. It a miracle that this works, but at least usually it like it does, but sometimes tar will complain about a missing file, failing the install. I've confirmed locally that this is due to the race described above.

To fix this, we use `throttle: 1` on the unpack task. This means that the first task (for each architecture) will do the unpack and the other tasks are effectively no-ops, they are reported as "ok" rather than changed in the output.

Fixes #457.