### PR TITLE
skip_changelog: Pin almalinux to old container images

### DIFF
--- a/.config/molecule/config.yml
+++ b/.config/molecule/config.yml
@@ -6,13 +6,13 @@ driver:
   name: docker
 platforms:
   - name: almalinux-8
-    image: ghcr.io/test-kitchen/dokken/almalinux-8
+    image: ghcr.io/test-kitchen/dokken/almalinux-8:sha-f9f79cb
     pre_build_image: true
     privileged: true
     cgroup_parent: docker.slice
     command: /lib/systemd/systemd
   - name: almalinux-9
-    image: ghcr.io/test-kitchen/dokken/almalinux-9
+    image: ghcr.io/test-kitchen/dokken/almalinux-9:sha-f9f79cb
     pre_build_image: true
     privileged: true
     cgroup_parent: docker.slice


### PR DESCRIPTION
Test if rolling back almalinux fixes build issues.