### PR TITLE
fix: prometheus_global values

### DIFF
--- a/roles/prometheus/defaults/main.yml
+++ b/roles/prometheus/defaults/main.yml
@@ -49,9 +49,9 @@ prometheus_alert_relabel_configs: []
 #     regex: replica
 
 prometheus_global:
-  scrape_interval: 15s
+  scrape_interval: 1m
   scrape_timeout: 10s
-  evaluation_interval: 15s
+  evaluation_interval: 1m
 
 prometheus_remote_write: []
 # prometheus_remote_write:

--- a/roles/prometheus/meta/argument_specs.yml
+++ b/roles/prometheus/meta/argument_specs.yml
@@ -83,9 +83,9 @@ argument_specs:
           - "Prometheus global config. It is compatible with the L(official configuration,https://prometheus.io/docs/prometheus/latest/configuration/configuration/#configuration-file)"
         type: "dict"
         default:
-          scrape_interval: "60s"
-          scrape_timeout: "15s"
-          evaluation_interval: "15s"
+          scrape_interval: "1m"
+          scrape_timeout: "10s"
+          evaluation_interval: "1m"
       prometheus_remote_write:
         description:
           - "Remote write. Compatible with the L(official configuration,https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write)"


### PR DESCRIPTION
Although the value of `prometheus_global` says “It is compatible with the official configuration.”
It seems to be at variance with the default value described at https://prometheus.io/docs/prometheus/latest/configuration/configuration/#configuration-file.