### PR TITLE
skip_changelog: Switch release to ansible-core

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: "Install tools"
-        run: "python -m pip install --upgrade ansible-base antsibull-changelog --disable-pip-version-check"
+        run: "python -m pip install --upgrade ansible-core antsibull-changelog --disable-pip-version-check"
 
       - name: "Calculate next version"
         id: version


### PR DESCRIPTION
I belive `ansible-base` is obsolete and has been replaced with `ansible-core`. This should fix Python 3.12 compatibility.

Fixes: https://github.com/prometheus-community/ansible/issues/522