### PR TITLE
fix: add check_mode to the checksum task

### DIFF
--- a/roles/_common/tasks/install.yml
+++ b/roles/_common/tasks/install.yml
@@ -90,6 +90,7 @@
             return_content: true
             status_code: [200, 203, 204, 206, 300, 301, 302, 303, 304, 307, 308]
             follow_redirects: all
+          check_mode: false
           register: __common_binary_checksums_raw
 
         - name: "Parse checksum list for {{ __common_binary_basename }}"

--- a/roles/_common/tasks/install.yml
+++ b/roles/_common/tasks/install.yml
@@ -80,6 +80,7 @@
 
     - name: "Verify checksum of {{ __common_binary_basename }}"
       run_once: true
+      check_mode: false
       when: (_common_checksums_url)
       block:
         - name: "Fetch checksum list for {{ __common_binary_basename }}"
@@ -90,7 +91,6 @@
             return_content: true
             status_code: [200, 203, 204, 206, 300, 301, 302, 303, 304, 307, 308]
             follow_redirects: all
-          check_mode: false
           register: __common_binary_checksums_raw
 
         - name: "Parse checksum list for {{ __common_binary_basename }}"


### PR DESCRIPTION
This PR adds the `check_mode: false` in the fetch checksum task.

This is needed because the next task, which parses the checksum list, expects the checksum files to already be downloaded. Without `check_mode: false`, the task only runs in "simulation" mode and doesn't download the files.

This "bug" was introduced during a refactor: https://github.com/prometheus-community/ansible/commit/6209b53314d61b375578572e9b4df7e120ce3066

Without `check_mode: false`:

```
TASK [prometheus.prometheus._common : Fetch checksum list for prometheus-2.48.1.linux-amd64.tar.gz] ***********************************************************************
skipping: [node]

TASK [prometheus.prometheus._common : Parse checksum list for prometheus-2.48.1.linux-amd64.tar.gz] ***********************************************************************
fatal: [node -> localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'content'. 'dict object' has no attribute 'content'\n\nThe error appears to be in '/home/slococo/.local/share/ansible/collections/ansible_collections/prometheus/prometheus/roles/_common/tasks/install.yml': line 95, column 11, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n        - name: \"Parse checksum list for {{ __common_binary_basename }}\"\n          ^ here\nWe could be wrong, but this one looks like it might be an issue with\nmissing quotes. Always quote
template expression brackets when they\nstart a value. For instance:\n\n    with_items:\n      - {{ foo }}\n\nShould be written as:\n\n    with_items:\n      - \"{{ foo }}\"\n"}
```

With `check_mode: false`:
```
TASK [prometheus.prometheus._common : Fetch checksum list for prometheus-2.48.1.linux-amd64.tar.gz] ***********************************************************************
ok: [node -> localhost]

TASK [prometheus.prometheus._common : Parse checksum list for prometheus-2.48.1.linux-amd64.tar.gz] ***********************************************************************
ok: [node -> localhost]
```