### PR TITLE
fix: identation in service file

### DIFF
--- a/roles/prometheus/templates/prometheus.service.j2
+++ b/roles/prometheus/templates/prometheus.service.j2
@@ -30,7 +30,7 @@ ExecStart={{ prometheus_binary_install_dir }}/prometheus \
   --storage.agent.path={{ prometheus_db_dir }} \
 {% endif %}
 {% if (prometheus_version is version('2.24.0', '>=')) and (prometheus_web_config.values() | map('length') | select('gt', 0) | list is any) %}
-    --web.config.file={{ prometheus_config_dir }}/web_config.yml \
+  --web.config.file={{ prometheus_config_dir }}/web_config.yml \
 {% endif %}
   --web.console.libraries={{ prometheus_config_dir }}/console_libraries \
   --web.console.templates={{ prometheus_config_dir }}/consoles \


### PR DESCRIPTION
Small PR to fix identation of argument in prometheus.service file

Before:
```
...
  --storage.tsdb.retention.size=0 \
    --web.config.file=/etc/prometheus/web_config.yml \
  --web.console.libraries=/etc/prometheus/console_libraries \
...
```

After:
```
...
  --storage.tsdb.retention.size=0 \
  --web.config.file=/etc/prometheus/web_config.yml \
  --web.console.libraries=/etc/prometheus/console_libraries \
...
```