### PR TITLE
fix: add `enabled: true` to alertmanager

### DIFF
--- a/roles/alertmanager/tasks/main.yml
+++ b/roles/alertmanager/tasks/main.yml
@@ -55,7 +55,7 @@
     name: alertmanager
     enabled: true
     state: started
-  when:
-    - not ansible_check_mode
   tags:
+    - alertmanager
+    - run
     - alertmanager_run

--- a/roles/alertmanager/tasks/main.yml
+++ b/roles/alertmanager/tasks/main.yml
@@ -47,3 +47,15 @@
     - alertmanager
     - configure
     - alertmanager_configure
+
+- name: Ensure alertmanager is enabled on boot
+  become: true
+  ansible.builtin.systemd:
+    daemon_reload: true
+    name: alertmanager
+    enabled: true
+    state: started
+  when:
+    - not ansible_check_mode
+  tags:
+    - alertmanager_run


### PR DESCRIPTION
Only in the `alertmanager` was there no written setting that would be enabled on boot.

```bash
$ for f in roles/*/tasks/main.yml; do grep -q 'enabled: true' $f || echo $f; done
roles/alertmanager/tasks/main.yml
```