### PR TITLE
skip_changelog: Update GitHub actions

### DIFF
--- a/.github/workflows/ansible-ci.yml
+++ b/.github/workflows/ansible-ci.yml
@@ -24,7 +24,7 @@ jobs:
   ansible-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Lint collection
         uses: ansible/ansible-lint@main
@@ -34,14 +34,14 @@ jobs:
     container:
       image: quay.io/prometheus/golang-builder:base
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Lint arguments spec
         run: ./.github/scripts/lint_arguments_spec.sh
 
   check-unused-variables:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Run action
         uses: hoo29/little-timmy@v2-action
 
@@ -50,7 +50,7 @@ jobs:
     outputs:
       versions: ${{ steps.supported-ansible-versions.outputs.result }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Get Ansible versions that the collection supports
         id: supported-ansible-versions
@@ -72,7 +72,7 @@ jobs:
       integration-tests: ${{ steps.set-integration-tests.outputs.tests }}
       ansible-roles: ${{ steps.set-ansible-roles.outputs.roles }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ansible-test-integration.yml
+++ b/.github/workflows/ansible-test-integration.yml
@@ -33,7 +33,7 @@ jobs:
     name: "${{ matrix.targets.name }}-${{ matrix.ansible-core-versions }}"
     steps:
       - name: "Perform ${{ matrix.targets.test }} integration test with ansible-test"
-        uses: ansible-community/ansible-test-gh-action@release/v1
+        uses: ansible-community/ansible-test-gh-action@e083357d3acff9e6631b0ad08d8ca4421e5a75d3  # v1.16.0
         with:
           ansible-core-version: ${{ matrix.ansible-core-versions }}
           target-python-version: ${{ matrix.target-python-versions }}

--- a/.github/workflows/ansible-test-molecule.yml
+++ b/.github/workflows/ansible-test-molecule.yml
@@ -19,7 +19,7 @@ jobs:
 
     name: "${{ inputs.role }}-discover-molecule-scenarios"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ansible-test-sanity.yml
+++ b/.github/workflows/ansible-test-sanity.yml
@@ -19,7 +19,7 @@ jobs:
     name: "sanity-${{ matrix.ansible-core-versions }}"
     steps:
       - name: "Perform sanity test with ansible-test"
-        uses: ansible-community/ansible-test-gh-action@release/v1
+        uses: ansible-community/ansible-test-gh-action@e083357d3acff9e6631b0ad08d8ca4421e5a75d3  # v1.16.0
         with:
           ansible-core-version: ${{ matrix.ansible-core-versions }}
           testing-type: sanity

--- a/.github/workflows/conventional-label.yml
+++ b/.github/workflows/conventional-label.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     steps:
       - name: "Confirm correct pull request title"
-        uses: mmubeen/action-pr-title@master  # until PR gets merged https://github.com/deepakputhraya/action-pr-title/pull/29
+        uses: deepakputhraya/action-pr-title@077bddd7bdabd0d2b1b25ed0754c7e62e184d7ee
         with:
           allowed_prefixes: "breaking,chore,feat,feature,fix,major,minor,enhancement,\
            deprecated,removed,security,bug,bugfix,docs,packaging,\
@@ -22,7 +22,7 @@ jobs:
 
       - name: "Apply label"
         if: github.event.pull_request.labels.length == 0
-        uses: bcoe/conventional-release-labels@v1
+        uses: bcoe/conventional-release-labels@886f696738527c7be444262c327c89436dfb95a8  # v1.3.1
         with:
           type_labels: |
               {
@@ -54,21 +54,14 @@ jobs:
     needs: pr-label
     if: github.event.pull_request.labels.length == 0
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Get changed roles
         id: changed-roles
-        uses: tj-actions/changed-files@v45
-        with:
-          path: "roles"
-          diff_relative: "true"
-          files: "**"
-          dir_names: "true"
-          dir_names_max_depth: "1"
-          sha: ${{ github.event.pull_request.head.sha }}
+        run: git diff --name-only ${{ github.event.pull_request.head.sha }} -r | grep -E '^roles/' | cut -f 1-2 -d'/' | sort -u >> "$GITHUB_OUTPUT"
 
       - name: Add changed roles labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         if: |
           steps.changed-roles.outputs.all_changed_and_modified_files
         with:

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Get the latest tag
         id: get-latest-tag
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           script: |
             const latestTag = await github.rest.repos.listTags({

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Get the latest tag
         id: get-latest-tag
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           script: |
             const latestTag = await github.rest.repos.listTags({

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,14 +10,14 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: "Build the collection"
         id: build-collection
         uses: ansible-community/github-action-build-collection@main
 
       - name: "Upload built collection to release"
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@2b4adf59f26ea3ed6ddecb8e00f80acc6bc16bd4  # 2.9.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{ steps.build-collection.outputs.artifact-filename }}
@@ -26,6 +26,6 @@ jobs:
           overwrite: true
 
       - name: "Publish collection on galaxy"
-        uses: ansible/ansible-publish-action@v1.0.0
+        uses: ansible/ansible-publish-action@a56a0328c92c1d4feedf5bd7f7cf7ec7a4ae3f09  # v1.0.0
         with:
           api_key: ${{ secrets.ANSIBLE_GALAXY_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
 
@@ -45,19 +45,19 @@ jobs:
           cmd: yq -i '.version = "${{ steps.version.outputs.next-version }}"' 'galaxy.yml'
 
       - name: "Write changelog and version"
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@e348103e9026cc0eee72ae06630dbe30c8bf7a79  # v5.1.0
         with:
           branch: ${{ github.event.pull_request.base.ref }}
           commit_message: "chore: update version"
           push_options: --force
 
       - name: "Checkout updated branch"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           ref: ${{ github.event.pull_request.base.ref }}
 
       - name: "Publish release"
         id: release-publish
-        uses: release-drafter/release-drafter@v6
+        uses: release-drafter/release-drafter@7cf306f56b79636bb76931494ccf29fc893763bd  # v6.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/version_bumper.yml
+++ b/.github/workflows/version_bumper.yml
@@ -16,7 +16,7 @@ jobs:
     container:
       image: quay.io/prometheus/golang-builder:base
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Get repos for each role
         id: discover
@@ -36,5 +36,5 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.discover-role-repos.outputs.role-repos) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - run: ./.github/scripts/version_updater.sh ${{ matrix.repo }} ${{ matrix.role }} ${{ matrix.type }}


### PR DESCRIPTION
Update various github actions to pin SHA for supply chain security.
* Replace `tj-actions/changed-files` due to CVE-2023-51664.
