### PR TITLE
skip_changelog: Update supported testing

### DIFF
--- a/.config/molecule/config.yml
+++ b/.config/molecule/config.yml
@@ -61,6 +61,9 @@ provisioner:
         exclude_ansible_vers:
           - "2.17"
           - "2.18"
+      ubuntu-20.04:
+        exclude_ansible_vers:
+          - "2.18"
       ubuntu-24.04:
         exclude_ansible_vers:
           - "2.9"


### PR DESCRIPTION
Ignore Ansible 2.18 on Ubuntu 20.04 as it appears to have broken Python 3.8 support.