### PR TITLE
removed: drop Ubuntu 20.04 (Focal Fossa) support as it is EOL

### DIFF
--- a/.config/molecule/config.yml
+++ b/.config/molecule/config.yml
@@ -23,12 +23,6 @@ platforms:
     privileged: true
     cgroup_parent: docker.slice
     command: /lib/systemd/systemd
-  - name: ubuntu-20.04
-    image: ghcr.io/test-kitchen/dokken/ubuntu-20.04
-    pre_build_image: true
-    privileged: true
-    cgroup_parent: docker.slice
-    command: /lib/systemd/systemd
   - name: ubuntu-22.04
     image: ghcr.io/test-kitchen/dokken/ubuntu-22.04
     pre_build_image: true
@@ -61,11 +55,3 @@ provisioner:
         exclude_ansible_vers:
           - "2.17"
           - "2.18"
-      ubuntu-20.04:
-        exclude_ansible_vers:
-          - "2.18"
-      ubuntu-24.04:
-        exclude_ansible_vers:
-          - "2.9"
-          - "2.10"
-          - "2.11"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.9.0,<=2.18.99"
+requires_ansible: ">=2.12.0,<=2.18.99"

--- a/roles/_common/meta/main.yml
+++ b/roles/_common/meta/main.yml
@@ -3,4 +3,4 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Internal role for common tasks shared between roles"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"

--- a/roles/alertmanager/meta/main.yml
+++ b/roles/alertmanager/meta/main.yml
@@ -3,11 +3,10 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus Alertmanager service"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
-        - "focal"
         - "jammy"
         - "noble"
     - name: "Debian"

--- a/roles/apache_exporter/meta/main.yml
+++ b/roles/apache_exporter/meta/main.yml
@@ -3,11 +3,10 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus apache_exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
-        - "focal"
         - "jammy"
         - "noble"
     - name: "Debian"

--- a/roles/bind_exporter/meta/main.yml
+++ b/roles/bind_exporter/meta/main.yml
@@ -3,11 +3,10 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus BIND Exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
-        - "focal"
         - "jammy"
         - "noble"
     - name: "Debian"

--- a/roles/blackbox_exporter/meta/main.yml
+++ b/roles/blackbox_exporter/meta/main.yml
@@ -3,11 +3,10 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus Blackbox Exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
-        - "focal"
         - "jammy"
         - "noble"
     - name: "Debian"

--- a/roles/cadvisor/meta/main.yml
+++ b/roles/cadvisor/meta/main.yml
@@ -3,11 +3,10 @@ galaxy_info:
   author: "cAdvisor Authors"
   description: "cAdvisor"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
-        - "focal"
         - "jammy"
         - "noble"
     - name: "Debian"

--- a/roles/chrony_exporter/meta/main.yml
+++ b/roles/chrony_exporter/meta/main.yml
@@ -3,11 +3,10 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus Chrony Exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
-        - "focal"
         - "jammy"
         - "noble"
     - name: "Debian"

--- a/roles/consul_exporter/meta/main.yml
+++ b/roles/consul_exporter/meta/main.yml
@@ -3,11 +3,10 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus Consul Exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
-        - "focal"
         - "jammy"
         - "noble"
     - name: "Debian"

--- a/roles/fail2ban_exporter/meta/main.yml
+++ b/roles/fail2ban_exporter/meta/main.yml
@@ -3,11 +3,10 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus fail2ban_exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
-        - "focal"
         - "jammy"
         - "noble"
     - name: "Debian"

--- a/roles/influxdb_exporter/meta/main.yml
+++ b/roles/influxdb_exporter/meta/main.yml
@@ -3,11 +3,10 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus Influxdb Exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
-        - "focal"
         - "jammy"
         - "noble"
     - name: "Debian"

--- a/roles/ipmi_exporter/meta/main.yml
+++ b/roles/ipmi_exporter/meta/main.yml
@@ -3,11 +3,10 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus ipmi_exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
-        - "focal"
         - "jammy"
         - "noble"
     - name: "Debian"

--- a/roles/memcached_exporter/meta/main.yml
+++ b/roles/memcached_exporter/meta/main.yml
@@ -3,11 +3,10 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus memcached_exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
-        - "focal"
         - "jammy"
         - "noble"
     - name: "Debian"

--- a/roles/mongodb_exporter/meta/main.yml
+++ b/roles/mongodb_exporter/meta/main.yml
@@ -3,11 +3,10 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus mongodb_exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
-        - "focal"
         - "jammy"
         - "noble"
     - name: "Debian"

--- a/roles/mysqld_exporter/meta/main.yml
+++ b/roles/mysqld_exporter/meta/main.yml
@@ -3,11 +3,10 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus MySQLd Exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
-        - "focal"
         - "jammy"
         - "noble"
     - name: "Debian"

--- a/roles/nginx_exporter/meta/main.yml
+++ b/roles/nginx_exporter/meta/main.yml
@@ -3,11 +3,10 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus nginx_exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
-        - "focal"
         - "jammy"
         - "noble"
     - name: "Debian"

--- a/roles/node_exporter/meta/main.yml
+++ b/roles/node_exporter/meta/main.yml
@@ -3,11 +3,10 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus Node Exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
-        - "focal"
         - "jammy"
         - "noble"
     - name: "Debian"

--- a/roles/nvidia_gpu_exporter/meta/main.yml
+++ b/roles/nvidia_gpu_exporter/meta/main.yml
@@ -3,11 +3,10 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Nvidia GPU exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
-        - "focal"
         - "jammy"
         - "noble"
     - name: "Debian"

--- a/roles/postgres_exporter/meta/main.yml
+++ b/roles/postgres_exporter/meta/main.yml
@@ -3,11 +3,10 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus PostgreSQL Exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
-        - "focal"
         - "jammy"
         - "noble"
     - name: "Debian"

--- a/roles/process_exporter/meta/main.yml
+++ b/roles/process_exporter/meta/main.yml
@@ -3,11 +3,10 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus Process Exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
-        - "focal"
         - "jammy"
         - "noble"
     - name: "Debian"

--- a/roles/prometheus/meta/main.yml
+++ b/roles/prometheus/meta/main.yml
@@ -3,11 +3,10 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus monitoring system configuration and management"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
-        - "focal"
         - "jammy"
         - "noble"
     - name: "Debian"

--- a/roles/pushgateway/meta/main.yml
+++ b/roles/pushgateway/meta/main.yml
@@ -3,11 +3,10 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus Pushgateway"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
-        - "focal"
         - "jammy"
         - "noble"
     - name: "Debian"

--- a/roles/redis_exporter/meta/main.yml
+++ b/roles/redis_exporter/meta/main.yml
@@ -3,11 +3,10 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus redis_exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
-        - "focal"
         - "jammy"
         - "noble"
     - name: "Debian"

--- a/roles/smartctl_exporter/meta/main.yml
+++ b/roles/smartctl_exporter/meta/main.yml
@@ -3,11 +3,10 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus Smartctl Exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
-        - "focal"
         - "jammy"
         - "noble"
     - name: "Debian"

--- a/roles/smokeping_prober/meta/main.yml
+++ b/roles/smokeping_prober/meta/main.yml
@@ -3,11 +3,10 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus Smokeping Prober"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
-        - "focal"
         - "jammy"
         - "noble"
     - name: "Debian"

--- a/roles/snmp_exporter/meta/main.yml
+++ b/roles/snmp_exporter/meta/main.yml
@@ -3,11 +3,10 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus SNMP Exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
-        - "focal"
         - "jammy"
         - "noble"
     - name: "Debian"

--- a/roles/systemd_exporter/meta/main.yml
+++ b/roles/systemd_exporter/meta/main.yml
@@ -3,11 +3,10 @@ galaxy_info:
   author: "Prometheus Community"
   description: "Prometheus Systemd Exporter"
   license: "Apache"
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.12"
   platforms:
     - name: "Ubuntu"
       versions:
-        - "focal"
         - "jammy"
         - "xenial"
         - "noble"

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,1 +1,0 @@
-.github/scripts/collection_version_parser.py shebang  # https://github.com/ansible/ansible/issues/78346

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,1 +1,0 @@
-.github/scripts/collection_version_parser.py shebang  # https://github.com/ansible/ansible/issues/78346

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,1 +1,0 @@
-.github/scripts/collection_version_parser.py shebang  # https://github.com/ansible/ansible/issues/78346


### PR DESCRIPTION
https://ubuntu.com/blog/ubuntu-20-04-eol-for-devicesional