### PR TITLE
fix(snmp_exporter): Added when clause to snmp_exporter role

### DIFF
--- a/roles/snmp_exporter/tasks/main.yml
+++ b/roles/snmp_exporter/tasks/main.yml
@@ -47,5 +47,7 @@
     name: snmp_exporter
     state: started
     enabled: true
+  when:
+    - not ansible_check_mode
   tags:
     - snmp_exporter_run


### PR DESCRIPTION
Added when clause to Ensure snmp_exporter service is started and enabled to not run in check mode
https://github.com/prometheus-community/ansible/issues/609