### PR TITLE
use explicit bool instead of implicit truthy

### DIFF
--- a/roles/_common/tasks/configure.yml
+++ b/roles/_common/tasks/configure.yml
@@ -33,7 +33,7 @@
   become: true
   notify:
     - "{{ ansible_parent_role_names | first }} : Restart {{ _common_service_name }}"
-  when: (_common_config_dir)
+  when: (_common_config_dir | length > 0)
   tags:
     - "{{ ansible_parent_role_names | first | regex_replace(ansible_collection_name ~ '.', '') }}"
     - configure

--- a/roles/_common/tasks/install.yml
+++ b/roles/_common/tasks/install.yml
@@ -81,7 +81,7 @@
     - name: "Verify checksum of {{ __common_binary_basename }}"
       run_once: true
       check_mode: false
-      when: (_common_checksums_url)
+      when: (_common_checksums_url | length > 0)
       block:
         - name: "Fetch checksum list for {{ __common_binary_basename }}"
           ansible.builtin.uri:

--- a/roles/_common/tasks/preflight.yml
+++ b/roles/_common/tasks/preflight.yml
@@ -57,7 +57,7 @@
   ansible.builtin.package:
     name: "{{ _common_dependencies }}"
     state: present
-  when: (_common_dependencies)
+  when: (_common_dependencies != None)
   tags:
     - "{{ ansible_parent_role_names | first | regex_replace(ansible_collection_name ~ '.', '') }}"
     - configure
@@ -84,4 +84,4 @@
           reject('match', '.+:\\d+$') |
           list |
           length == 0
-  when: (_common_web_listen_address)
+  when: (_common_web_listen_address | length > 0)


### PR DESCRIPTION
# Why

With Ansible 2.19 implicit truthy is no longer allowed and ansible errors.

## Changes

This commit adds explicit checks which returns boolean.

## Thoughts

For variables which are defined as:
```yaml
_common_checksums_url: ""
```
I have add a check for length, because they count as defined.

Variables which are not clear, for example:
```yaml
_common_dependencies
```
I have tested what they can be. In this example `null` or `"python3-apt "`.
(I have no idea why there is a space after `...-apt`)

For some reason `null` counts as defined. I have checked it with `_common_dependencies is defined`

## Sources
https://ansible.readthedocs.io/projects/ansible-core/devel/porting_guides/porting_guide_core_2.19.html#broken-conditionals