### PR TITLE
enhancement - Update handlers to allow skipping snmp_exporter handlers

### DIFF
--- a/roles/snmp_exporter/handlers/main.yml
+++ b/roles/snmp_exporter/handlers/main.yml
@@ -7,6 +7,7 @@
     name: snmp_exporter
     state: restarted
   register: snmp_exporter_restarted
+  when: "'snmp_exporter_restart' not in ansible_skip_tags"
 
 - name: Reload snmp_exporter
   listen: "reload snmp_exporter"
@@ -15,4 +16,6 @@
     daemon_reload: true
     name: snmp_exporter
     state: reloaded
-  when: snmp_exporter_restarted is not defined
+  when:
+    - snmp_exporter_restarted is not defined
+    - "'snmp_exporter_restart' not in ansible_skip_tags"


### PR DESCRIPTION
We've run into an issue often when standing up new hosts running snmp_exporters that our dry-run process against that new node fails due to the handlers attempting to run and failing since snmp_exporter hasn't yet installed it's systemd service.

This change allows us to skip running those handlers when the `ansible_skip_tags` magic variable contains the new tag `snmp_exporter_restart` this would be passed on the command line via `--skip-tags` per usual and allow us to skip solely that tag during our dry-run stages.