### PR TITLE
fix: Conditionals must have a boolean result

### DIFF
--- a/.config/molecule/alternative/prepare.yml
+++ b/.config/molecule/alternative/prepare.yml
@@ -14,7 +14,7 @@
         path: "{{ __cache_path }}"
         state: directory
         mode: 0755
-      when: (__cache_path)
+      when: __cache_path is defined and __cache_path | length > 0
 
     - name: "Fetch binary"
       become: false
@@ -28,7 +28,7 @@
         creates: "{{ __cache_path }}/{{ __binary_name }}"
       check_mode: false
       register: __download_binary
-      when: (__binary_url)
+      when: __binary_url is defined and __binary_url | length > 0
 
     - name: Generate self signed certificates
       when: "'cert_file' in __tls_server_config"

--- a/roles/_common/tasks/configure.yml
+++ b/roles/_common/tasks/configure.yml
@@ -33,7 +33,7 @@
   become: true
   notify:
     - "{{ ansible_parent_role_names | first }} : Restart {{ _common_service_name }}"
-  when: (_common_config_dir)
+  when: _common_config_dir is defined and _common_config_dir | length > 0
   tags:
     - "{{ ansible_parent_role_names | first | regex_replace(ansible_collection_name ~ '.', '') }}"
     - configure

--- a/roles/_common/tasks/install.yml
+++ b/roles/_common/tasks/install.yml
@@ -81,7 +81,7 @@
     - name: "Verify checksum of {{ __common_binary_basename }}"
       run_once: true
       check_mode: false
-      when: (_common_checksums_url)
+      when: _common_checksums_url is defined and _common_checksums_url | length > 0
       block:
         - name: "Fetch checksum list for {{ __common_binary_basename }}"
           ansible.builtin.uri:

--- a/roles/_common/tasks/preflight.yml
+++ b/roles/_common/tasks/preflight.yml
@@ -57,7 +57,7 @@
   ansible.builtin.package:
     name: "{{ _common_dependencies }}"
     state: present
-  when: (_common_dependencies)
+  when: _common_dependencies is defined and _common_dependencies | length > 0
   tags:
     - "{{ ansible_parent_role_names | first | regex_replace(ansible_collection_name ~ '.', '') }}"
     - configure
@@ -84,4 +84,4 @@
           reject('match', '.+:\\d+$') |
           list |
           length == 0
-  when: (_common_web_listen_address)
+  when: _common_web_listen_address is defined and _common_web_listen_address | length > 0


### PR DESCRIPTION
See https://github.com/ansible/ansible/blob/stable-2.19/changelogs/CHANGELOG-v2.19.rst#breaking-changes--porting-guide:

> conditionals - Conditional expressions that result in non-boolean values are now an error by default. Such results often indicate unintentional use of templates where they are not supported, resulting in a conditional that is always true. When this option is enabled, conditional expressions which are a literal None or empty string will evaluate as true, for backwards compatibility. The error can be temporarily changed to a deprecation warning by enabling the ALLOW_BROKEN_CONDITIONALS config option.

This PR follows https://ansible.readthedocs.io/projects/ansible-core/devel/porting_guides/porting_guide_core_2.19.html#broken-conditionals and changed implicit boolean conversions to explicit ones.