### PR TITLE
fix: remove trailing space in dependencies when using APT

### DIFF
--- a/roles/_common/vars/main.yml
+++ b/roles/_common/vars/main.yml
@@ -11,7 +11,7 @@ _common_service_name: "{{ __common_parent_role_short_name }}"
 _common_system_user: ""
 _common_system_group: ""
 _common_dependencies: "{% if (ansible_facts['pkg_mgr'] == 'apt') %}\
-                       {{ ('python-apt' if ansible_facts['python_version'] is version('3', '<') else 'python3-apt') }}
+                       {{ ('python-apt' if ansible_facts['python_version'] is version('3', '<') else 'python3-apt') }}\
                        {% else %}\
                        {% endif %}"
 _common_binary_unarchive_opts: ""

--- a/roles/blackbox_exporter/vars/main.yml
+++ b/roles/blackbox_exporter/vars/main.yml
@@ -8,6 +8,6 @@ _blackbox_exporter_repo: "prometheus/blackbox_exporter"
 _github_api_headers: "{{ {'GITHUB_TOKEN': lookup('ansible.builtin.env', 'GITHUB_TOKEN')} if (lookup('ansible.builtin.env', 'GITHUB_TOKEN')) else {} }}"
 _blackbox_exporter_binaries: ['blackbox_exporter']
 _blackbox_exporter_dependencies: "{% if (ansible_facts['pkg_mgr'] == 'apt') %}\
-                                  {{ (['python-apt', 'libcap2-bin'] if ansible_facts['python_version'] is version('3', '<') else ['python3-apt', 'libcap2-bin']) }}
+                                  {{ (['python-apt', 'libcap2-bin'] if ansible_facts['python_version'] is version('3', '<') else ['python3-apt', 'libcap2-bin']) }}\
                                   {% else %}\
                                   {% endif %}"


### PR DESCRIPTION
It's not a real issue when there is only one package but for for multiple packages (2 for blackbox), array is interpreted as a string because of the trailing space and prevent [package module](https://github.com/prometheus-community/ansible/blob/main/roles/_common/tasks/preflight.yml#L55) to works correctly (at least on my environment with ansible 2.19)