### PR TITLE
fix(blackbox_exporter): blackbox dependencies syntax

### DIFF
--- a/roles/_common/tasks/preflight.yml
+++ b/roles/_common/tasks/preflight.yml
@@ -55,9 +55,9 @@
 - name: Install dependencies
   become: true
   ansible.builtin.package:
-    name: "{{ item }}"
+    name: "{{ _common_dependencies }}"
     state: present
-  loop: "{{ _common_dependencies }}"
+  when: (_common_dependencies != None)
   tags:
     - "{{ ansible_parent_role_names | first | regex_replace(ansible_collection_name ~ '.', '') }}"
     - configure

--- a/roles/_common/vars/main.yml
+++ b/roles/_common/vars/main.yml
@@ -11,7 +11,7 @@ _common_service_name: "{{ __common_parent_role_short_name }}"
 _common_system_user: ""
 _common_system_group: ""
 _common_dependencies: "{% if (ansible_facts['pkg_mgr'] == 'apt') %}\
-                       {{ ('python-apt' if ansible_facts['python_version'] is version('3', '<') else 'python3-apt') }}\
+                       {{ ('python-apt' if ansible_facts['python_version'] is version('3', '<') else 'python3-apt') -}}\
                        {% else %}\
                        {% endif %}"
 _common_binary_unarchive_opts: ""

--- a/roles/blackbox_exporter/vars/main.yml
+++ b/roles/blackbox_exporter/vars/main.yml
@@ -8,6 +8,6 @@ _blackbox_exporter_repo: "prometheus/blackbox_exporter"
 _github_api_headers: "{{ {'GITHUB_TOKEN': lookup('ansible.builtin.env', 'GITHUB_TOKEN')} if (lookup('ansible.builtin.env', 'GITHUB_TOKEN')) else {} }}"
 _blackbox_exporter_binaries: ['blackbox_exporter']
 _blackbox_exporter_dependencies: "{% if (ansible_facts['pkg_mgr'] == 'apt') %}\
-                                  {{ (['python-apt', 'libcap2-bin'] if ansible_facts['python_version'] is version('3', '<') else ['python3-apt', 'libcap2-bin']) }}\
+                                  {{ (['python-apt', 'libcap2-bin'] if ansible_facts['python_version'] is version('3', '<') else ['python3-apt', 'libcap2-bin']) -}}\
                                   {% else %}\
                                   {% endif %}"


### PR DESCRIPTION
Fixes #667

The yaml syntax was such that the dependency list was a string (`"['python3-apt', 'libcap2-bin'] "` — note the whitespace at the end!), not a list, and caused errors described in #667 