### PR TITLE
feat(snmp-exporter): allow skipping snmp config copying step

### DIFF
--- a/roles/snmp_exporter/defaults/main.yml
+++ b/roles/snmp_exporter/defaults/main.yml
@@ -8,6 +8,7 @@ snmp_exporter_log_level: info
 
 # If this is empty, role will download snmp.yml file from https://github.com/prometheus/snmp_exporter.
 snmp_exporter_config_file: ""
+snmp_exporter_configure: true
 
 snmp_exporter_binary_install_dir: "/usr/local/bin"
 snmp_exporter_config_dir: "/etc/snmp_exporter"

--- a/roles/snmp_exporter/meta/argument_specs.yml
+++ b/roles/snmp_exporter/meta/argument_specs.yml
@@ -27,6 +27,11 @@ argument_specs:
         description:
           - "If this is empty, role will download snmp.yml file from U(https://github.com/prometheus/snmp_exporter)."
           - "Otherwise this should contain path to file with custom snmp exporter configuration"
+      snmp_exporter_configure:
+        description:
+          - "Whether this role manages the snmp_exporter configuration file (snmp.yml)."
+          - "Set to false to skip downloading/copying the config; use when the file is managed externally."
+        default: true
       snmp_exporter_binary_install_dir:
         description:
           - "I(Advanced)"

--- a/roles/snmp_exporter/tasks/configure.yml
+++ b/roles/snmp_exporter/tasks/configure.yml
@@ -13,6 +13,7 @@
     - snmp_exporter_configure
 
 - name: Copy configuration file
+  when: snmp_exporter_configure | default(true) | bool
   ansible.builtin.template:
     src: "{{ snmp_exporter_config_file | default(snmp_exporter_local_cache_path ~ '/snmp.yml', true) }}"
     dest: "{{ snmp_exporter_config_dir }}/snmp.yml"


### PR DESCRIPTION
This is needed for making it possible to externally manage the snmp config file without it being overwritten by this role