### PR TITLE
feature: Add Remote Download for _common and node_exporter

### DIFF
--- a/roles/_common/meta/argument_specs.yml
+++ b/roles/_common/meta/argument_specs.yml
@@ -69,6 +69,12 @@ argument_specs:
       _common_system_group:
         description: "User group for the system user."
         default: ""
+      _common_remote_download:
+        description: Determines if the package archive is downloaded and extracted on local (false) or remote host (true)"
+        default: "false"
+      _common_remote_cache_path:
+        description: "Remote path to stash the archive and its extraction"
+        default: ""
   preflight:
     short_description: "Internal only - common preflight tasks"
     description: "Internal only - selinux requirements"

--- a/roles/_common/tasks/install.yml
+++ b/roles/_common/tasks/install.yml
@@ -54,11 +54,11 @@
     - download
     - "{{ ansible_parent_role_names | first | regex_replace(ansible_collection_name ~ '.', '') }}_download"
   become: false
-  delegate_to: localhost
+  delegate_to: "{{ inventory_hostname if (_common_remote_download | bool) else 'localhost' }}"
   block:
     - name: "Create localhost binary cache path"
       ansible.builtin.file:
-        path: "{{ _common_local_cache_path }}"
+        path: "{{ _common_remote_cache_path if (_common_remote_download | bool) else _common_local_cache_path }}"
         state: directory
         mode: 0755
       check_mode: false
@@ -115,6 +115,7 @@
       ansible.builtin.unarchive:
         src: "{{ _common_local_cache_path }}/{{ __common_binary_basename }}"
         dest: "{{ _common_local_cache_path }}"
+        remote_src: "{{ _common_remote_download | bool }}"
         mode: 0755
         list_files: true
         extra_opts: "{{ _common_binary_unarchive_opts | default(omit, true) }}"
@@ -148,6 +149,7 @@
   ansible.builtin.copy:
     src: "{{ _common_local_cache_path }}/{{ item }}"
     dest: "{{ _common_binary_install_dir }}/{{ item }}"
+    remote_src: "{{ _common_remote_download | bool }}"
     mode: 0755
     owner: root
     group: root

--- a/roles/_common/vars/main.yml
+++ b/roles/_common/vars/main.yml
@@ -19,6 +19,8 @@ _common_tls_server_config: {}
 _common_http_server_config: {}
 _common_basic_auth_users: {}
 _common_web_listen_address: ""
+_common_remote_download: "false"
+_common_remote_cache_path: ""
 # Variables that should not be overwritten
 __common_binary_basename: "{{ _common_binary_url | urlsplit('path') | basename }}"
 __common_github_api_headers: "{{ {'GITHUB_TOKEN': lookup('ansible.builtin.env', 'GITHUB_TOKEN')} if (lookup('ansible.builtin.env', 'GITHUB_TOKEN')) else {} }}"

--- a/roles/node_exporter/defaults/main.yml
+++ b/roles/node_exporter/defaults/main.yml
@@ -33,3 +33,11 @@ node_exporter_system_user: "{{ node_exporter_system_group }}"
 node_exporter_config_dir: "/etc/node_exporter"
 # Local path to stash the archive and its extraction
 node_exporter_local_cache_path: "/tmp/node_exporter-{{ ansible_facts['system'] | lower }}-{{ _node_exporter_go_ansible_arch }}/{{ node_exporter_version }}"
+
+# If false (the default) we download node exporter archive and unpack it on localhost, before
+# uploading it to the remote host(s). If true we download and unpack the archive on the remote
+# host directly.
+node_exporter_remote_download: false
+
+# Remote path to stash the archive and its extraction
+node_exporter_remote_cache_path: "/tmp/node_exporter-{{ ansible_facts['system'] | lower }}-{{ _node_exporter_go_ansible_arch }}/{{ node_exporter_version }}"

--- a/roles/node_exporter/meta/argument_specs.yml
+++ b/roles/node_exporter/meta/argument_specs.yml
@@ -82,3 +82,9 @@ argument_specs:
       node_exporter_config_dir:
         description: "Path to directory with node_exporter configuration"
         default: "/etc/node_exporter"
+      node_exporter_remote_download:
+        description: "Determines if the node exporter package archive is downloaded and extracted on local (false) or remote host (true)"
+        default: false
+      node_exporter_remote_cache_path:
+        description: "Remote path to stash the archive and its extraction"
+        default: "/tmp/node_exporter-{{ ansible_facts['system'] | lower }}-{{ _node_exporter_go_ansible_arch }}/{{ node_exporter_version }}"

--- a/roles/node_exporter/tasks/main.yml
+++ b/roles/node_exporter/tasks/main.yml
@@ -21,6 +21,8 @@
     _common_system_user: "{{ node_exporter_system_user }}"
     _common_config_dir: "{{ node_exporter_config_dir }}"
     _common_binary_unarchive_opts: ['--strip-components=1']
+    _common_remote_download: "{{ node_exporter_remote_download }}"
+    _common_remote_cache_path: "{{ node_exporter_remote_cache_path }}"
   tags:
     - node_exporter_install
 


### PR DESCRIPTION
Following [PR-499](https://github.com/prometheus-community/ansible/pull/499) which has not been merged due to some conflict.

Currently, the node_exporter installation process always downloads the package to the localhost, unpacks it there, and then uploads it to the remote host.

This change introduces an optional behavior to _common/install, enabling direct download to the remote host. It's now wired for use by node_exporter through the node_exporter_localhost_download variable. The default behavior for node_exporter and other binaries remains unchanged: delegate to localhost. Additionally, these updates allow for customizing the remote cache directory where the binary can be downloaded.

Issues linked :
- [389](https://github.com/prometheus-community/ansible/issues/389)
- [645](https://github.com/prometheus-community/ansible/issues/645)