### PR TITLE
feat(blackbox_exporter): add configurable service name

### DIFF
--- a/roles/blackbox_exporter/defaults/main.yml
+++ b/roles/blackbox_exporter/defaults/main.yml
@@ -9,6 +9,8 @@ blackbox_exporter_web_listen_address: "0.0.0.0:9115"
 blackbox_exporter_system_user: blackbox-exp
 blackbox_exporter_system_group: "{{ blackbox_exporter_system_user }}"
 
+blackbox_exporter_service_name: blackbox_exporter
+
 blackbox_exporter_cli_flags: {}
 # blackbox_exporter_cli_flags:
 #   log.level: "warn"

--- a/roles/blackbox_exporter/handlers/main.yml
+++ b/roles/blackbox_exporter/handlers/main.yml
@@ -4,7 +4,7 @@
   become: true
   ansible.builtin.systemd:
     daemon_reload: true
-    name: blackbox_exporter
+    name: "{{ blackbox_exporter_service_name }}"
     state: restarted
   register: blackbox_exporter_restarted
 
@@ -12,6 +12,6 @@
   listen: "reload blackbox_exporter"
   become: true
   ansible.builtin.systemd:
-    name: blackbox_exporter
+    name: "{{ blackbox_exporter_service_name }}"
     state: reloaded
   when: blackbox_exporter_restarted is not defined

--- a/roles/blackbox_exporter/tasks/configure.yml
+++ b/roles/blackbox_exporter/tasks/configure.yml
@@ -7,6 +7,7 @@
     _common_system_user: "{{ blackbox_exporter_system_user }}"
     _common_system_group: "{{ blackbox_exporter_system_group }}"
     _common_config_dir: "{{ blackbox_exporter_config_dir }}"
+    _common_service_name: "{{ blackbox_exporter_service_name }}"
   tags:
     - blackbox_exporter
     - configure

--- a/roles/blackbox_exporter/tasks/main.yml
+++ b/roles/blackbox_exporter/tasks/main.yml
@@ -44,7 +44,7 @@
   become: true
   ansible.builtin.systemd:
     daemon_reload: true
-    name: blackbox_exporter
+    name: "{{ blackbox_exporter_service_name }}"
     state: started
     enabled: true
   tags:

--- a/roles/blackbox_exporter/templates/blackbox_exporter.service.j2
+++ b/roles/blackbox_exporter/templates/blackbox_exporter.service.j2
@@ -27,7 +27,7 @@ ExecStart={{ blackbox_exporter_binary_install_dir }}/blackbox_exporter \
   --web.listen-address={{ blackbox_exporter_web_listen_address }}
 {% endif %}
 
-SyslogIdentifier=blackbox_exporter
+SyslogIdentifier={{ blackbox_exporter_service_name }}
 KillMode=process
 Restart=always
 RestartSec=5


### PR DESCRIPTION
Adds blackbox_exporter_service_name variable to allow customizing the systemd service name. Defaults to 'blackbox_exporter' for backwards compatibility.