### PR TITLE
fix(smartctl_exporter): add kernel capabilities

### DIFF
--- a/roles/smartctl_exporter/templates/smartctl_exporter.service.j2
+++ b/roles/smartctl_exporter/templates/smartctl_exporter.service.j2
@@ -33,6 +33,11 @@ StartLimitInterval=0
 ProtectHome=yes
 NoNewPrivileges=yes
 
+{% if (ansible_facts.packages.systemd | first).version is version('229', '>=') %}
+AmbientCapabilities=CAP_SYS_RAWIO CAP_DAC_READ_SEARCH
+CapabilityBoundingSet=CAP_SYS_RAWIO CAP_DAC_READ_SEARCH
+{% endif %}
+
 {% if (ansible_facts.packages.systemd | first).version is version('232', '>=') %}
 ProtectSystem=strict
 ProtectControlGroups=true


### PR DESCRIPTION
The following patch adds the capabilities that the binary needs to access the disks without root privileges.

The capabilities were determined using the following command. The process ID `1259363` is that of `smartctl_exporter` when it was previously executed as root.

```bash
$ capsh --decode=$(grep CapBnd /proc/1259363/status | cut -f 2)
0x0000000000020004=cap_dac_read_search,cap_sys_rawio
```

The capabilities `CAP_DAC_READ_SEARCH` and `CAP_SYS_RAWIO` were added to the systemd unit, taking into account the systemd version.

With this patch can be smartctl_exporter successfully started.

A similar patch for the prometheus-smartctl-exporter has already been accepted for the Arch Linux package.

https://gitlab.archlinux.org/archlinux/packaging/packages/prometheus-smartctl-exporter/-/commit/b872776265474e9bd8b69ff128c002cf4b005f44