### PR TITLE
fix(cadvisor): Fix command line continuation

### DIFF
--- a/roles/cadvisor/templates/cadvisor.service.j2
+++ b/roles/cadvisor/templates/cadvisor.service.j2
@@ -28,8 +28,8 @@ ExecStart={{ cadvisor_binary_install_dir }}/cadvisor \
     '--store_container_labels={{ cadvisor_store_container_labels | lower }}' \
     '--listen_ip={{ cadvisor_listen_ip }}' \
     '--port={{ cadvisor_port }}' \
-    '--prometheus_endpoint={{ cadvisor_prometheus_endpoint }}'
-    '--housekeeping_interval={{ cadvisor_housekeeping_interval }}'
+    '--prometheus_endpoint={{ cadvisor_prometheus_endpoint }}' \
+    '--housekeeping_interval={{ cadvisor_housekeeping_interval }}' \
     '--max_housekeeping_interval={{ cadvisor_max_housekeeping_interval }}'
 
 SyslogIdentifier=cadvisor


### PR DESCRIPTION
Fix the backslash command line continuation of the cadvisor flags.