### PR TITLE
Add run tag to service status check

### DIFF
--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -58,3 +58,5 @@
   until: "__service_status.ansible_facts.services['prometheus.service'].state == 'running'"
   retries: 10
   delay: 5
+  tags:
+    - prometheus_run


### PR DESCRIPTION
The service status check should only be executed when prometheus was started by ansible.
It won't be started by ansible when the tag `prometheus_run` is skipped.

I need this change because I only use the ansible role to generate the prometheus configuration.
I then run the daemon using podman. I use `--skip-tags prometheus_run` to stop ansible from starting the prometheus daemon on the host. Therefore the service check will always fail.
See also the task just above the changed one where the tag is included as you would expect.