### PR TITLE
feat(prometheus): support tsdb.retention.percentage

### DIFF
--- a/roles/prometheus/defaults/main.yml
+++ b/roles/prometheus/defaults/main.yml
@@ -23,6 +23,10 @@ prometheus_storage_retention: "30d"
 # [EXPERIMENTAL] Maximum number of bytes that can be stored for blocks. Units
 # supported: KB, MB, GB, TB, PB.
 prometheus_storage_retention_size: "0"
+# Available since Prometheus 3.11.0
+# [EXPERIMENTAL] Maximum percentage of total disk space allowed for block
+# storage. Set to 0 to disable percentage-based retention.
+prometheus_storage_retention_percentage: "0"
 
 # The Agent mode optimizes Prometheus for the remote write use case: https://prometheus.io/blog/2021/11/16/agent/
 prometheus_agent_mode: false

--- a/roles/prometheus/meta/argument_specs.yml
+++ b/roles/prometheus/meta/argument_specs.yml
@@ -55,6 +55,12 @@ argument_specs:
           - "Maximum number of bytes that can be stored for blocks."
           - "Units supported: KB, MB, GB, TB, PB."
         default: "0"
+      prometheus_storage_retention_percentage:
+        description:
+          - "Maximum percent of total disk space allowed for block storage"
+          - "Set to 0 to disable percentage-based retention"
+          - "Supported only on Prometheus >= 3.11.0"
+        default: "0"
       prometheus_agent_mode:
         description:
           - "The Agent mode optimizes Prometheus for the remote write use case. It disables querying, alerting, and local storage, and replaces it with a customized TSDB WAL. L(Everything,https://prometheus.io/docs/prometheus/latest/feature_flags/#prometheus-agent) else stays the same."

--- a/roles/prometheus/molecule/alternative/molecule.yml
+++ b/roles/prometheus/molecule/alternative/molecule.yml
@@ -13,7 +13,6 @@ provisioner:
         prometheus_storage_retention: "60d"
         prometheus_storage_retention_size: "1GB"
         prometheus_config_flags_extra:
-          alertmanager.timeout: 10s
           web.enable-admin-api:
           enable-feature:
             - promql-at-modifier
@@ -88,7 +87,7 @@ provisioner:
                 target_label: instance
               - target_label: __address__
                 replacement: 127.0.0.1:9115  # Blackbox exporter.
-        prometheus_version: 2.25.2
+        prometheus_version: 3.13.0
         prometheus_stop_timeout: 1min
         prometheus_binary_url: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version\
                                 \ }}/prometheus-{{ prometheus_version }}.linux-amd64.tar.gz"

--- a/roles/prometheus/molecule/alternative/molecule.yml
+++ b/roles/prometheus/molecule/alternative/molecule.yml
@@ -12,6 +12,7 @@ provisioner:
           - /etc
         prometheus_storage_retention: "60d"
         prometheus_storage_retention_size: "1GB"
+        prometheus_storage_retention_percentage: 70
         prometheus_config_flags_extra:
           web.enable-admin-api:
           enable-feature:

--- a/roles/prometheus/templates/prometheus.service.j2
+++ b/roles/prometheus/templates/prometheus.service.j2
@@ -16,11 +16,15 @@ ExecReload=/bin/kill -HUP $MAINPID
 ExecStart={{ prometheus_binary_install_dir }}/prometheus \
 {% if not prometheus_agent_mode %}
   --storage.tsdb.path={{ prometheus_db_dir }} \
+{# If using Prometheus 3.11 or newer, don't set the TSDB retention flags at #}
+{# all, instead use the config file. #}
+{% if prometheus_version is version('3.11.0', '<') %}
 {% if prometheus_version is version('2.7.0', '>=') %}
   --storage.tsdb.retention.time={{ prometheus_storage_retention }} \
   --storage.tsdb.retention.size={{ prometheus_storage_retention_size }} \
 {% else %}
   --storage.tsdb.retention={{ prometheus_storage_retention }} \
+{% endif %}
 {% endif %}
 {% else %}
 {% if prometheus_version is version('3.0.0', '>=') %}

--- a/roles/prometheus/templates/prometheus.yml.j2
+++ b/roles/prometheus/templates/prometheus.yml.j2
@@ -13,6 +13,7 @@ storage:
     retention:
       time: {{ prometheus_storage_retention }}
       size: {{ prometheus_storage_retention_size }}
+      percentage: {{ prometheus_storage_retention_percentage }}
 {% endif %}
 
 {% if prometheus_remote_write != [] %}

--- a/roles/prometheus/templates/prometheus.yml.j2
+++ b/roles/prometheus/templates/prometheus.yml.j2
@@ -7,6 +7,14 @@ global:
   external_labels:
     {{ prometheus_external_labels | to_nice_yaml(indent=2,sort_keys=False) | indent(4, False) }}
 
+{% if prometheus_version is version('3.11.0', '>=') %}
+storage:
+  tsdb:
+    retention:
+      time: {{ prometheus_storage_retention }}
+      size: {{ prometheus_storage_retention_size }}
+{% endif %}
+
 {% if prometheus_remote_write != [] %}
 remote_write:
   {{ prometheus_remote_write | to_nice_yaml(indent=2,sort_keys=False) | indent(2, False) }}


### PR DESCRIPTION
Configure `storage.tsdb.retention` in the configuration file for versions of Prometheus 3.11.0 and greater, rather than deprecated command line flags. This allows for configuring [percentage-based retention](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#tsdb).
This closes #790.