### PR TITLE
chore(preflight): Use `vars` lookups

### DIFF
--- a/roles/_common/tasks/preflight.yml
+++ b/roles/_common/tasks/preflight.yml
@@ -11,7 +11,7 @@
 - name: "Check for deprecated skip_install variable"
   ansible.builtin.assert:
     that:
-      - __common_parent_role_short_name ~ '_skip_install' not in vars
+      - lookup('vars', __common_parent_role_short_name + '_skip_install') | length == 0
     fail_msg: "The variable {{ __common_parent_role_short_name ~ '_skip_install' }} is deprecated.
                Please use `--skip-tags {{ __common_parent_role_short_name }}_install` instead to skip the installation."
   tags:
@@ -22,7 +22,7 @@
 - name: "Check for deprecated binary_local_dir variable"
   ansible.builtin.assert:
     that:
-      - __common_parent_role_short_name ~ '_binary_local_dir' not in vars
+      - lookup('vars', __common_parent_role_short_name + '_binary_local_dir') | length == 0
     fail_msg: "The variable {{ __common_parent_role_short_name ~ '_binary_local_dir' }} is deprecated.
                Please use the variable {{ __common_parent_role_short_name ~ '_local_cache_path' }} instead"
   tags:
@@ -33,7 +33,7 @@
 - name: "Check for deprecated archive_path variable"
   ansible.builtin.assert:
     that:
-      - __common_parent_role_short_name ~ '_archive_path' not in vars
+      - lookup('vars', __common_parent_role_short_name + '_archive_path') | length == 0
     fail_msg: "The variable {{ __common_parent_role_short_name ~ '_archive_path' }} is deprecated.
                Please use the variable {{ __common_parent_role_short_name ~ '_local_cache_path' }} instead"
   tags:


### PR DESCRIPTION
Hello, 

I noticed this while installing the role.

Thanks for your feedback.

---

When installing the node exporter, the following warning show up:

    [DEPRECATION WARNING]: The internal "vars" dictionary is deprecated. This feature will be removed from ansible-core version 2.24.
    Origin: /tmp/.ansible/collections/ansible_collections/prometheus/prometheus/roles/_common/tasks/preflight.yml:14:9
    12   ansible.builtin.assert:
    13     that:
    14       - __common_parent_role_short_name ~ '_skip_install' not in vars

               ^ column 9
    [...]
    Use the `vars` and `varnames` lookups instead.

Indeed, Ansible advises to use vars lookups for these assertion checks.

Use `vars` lookups.

Link: https://github.com/ansible/ansible/pull/85673