### PR TITLE
chore(ci): Update the yamllint rules to match the ansible-lint rules

### DIFF
--- a/.config/molecule/alternative/prepare.yml
+++ b/.config/molecule/alternative/prepare.yml
@@ -13,7 +13,7 @@
       ansible.builtin.file:
         path: "{{ __cache_path }}"
         state: directory
-        mode: 0755
+        mode: "0755"
       when: __cache_path is truthy
 
     - name: "Fetch binary"

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -23,6 +23,12 @@ rules:
     max: 200
   truthy:
     check-keys: false
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: false
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true
 
 ignore: |
   changelogs/.plugin-cache.yaml


### PR DESCRIPTION
Updated the yamllint rules in accordance with Ansible Lint's suggested settings. Specifically, this addresses the following warning:

```
WARNING  Found incompatible custom yamllint configuration (.yamllint.yml), please either remove the file or edit it to comply with:
  - comments.min-spaces-from-content must be 1
  - comments-indentation must be false
  - octal-values.forbid-implicit-octal must be true
  - octal-values.forbid-explicit-octal must be true.

Read https://docs.ansible.com/projects/lint/rules/yaml/ for more details regarding why we have these requirements. Fix mode will not be available.
```