### PR TITLE
feat(snmp_exporter):add multiple config support

### DIFF
--- a/roles/snmp_exporter/defaults/main.yml
+++ b/roles/snmp_exporter/defaults/main.yml
@@ -9,6 +9,9 @@ snmp_exporter_log_level: info
 # If this is empty, role will download snmp.yml file from https://github.com/prometheus/snmp_exporter.
 snmp_exporter_config_file: ""
 
+# Define additional configuration file paths that should be loaded
+snmp_exporter_additional_configs: []
+
 snmp_exporter_binary_install_dir: "/usr/local/bin"
 snmp_exporter_config_dir: "/etc/snmp_exporter"
 

--- a/roles/snmp_exporter/meta/argument_specs.yml
+++ b/roles/snmp_exporter/meta/argument_specs.yml
@@ -27,6 +27,12 @@ argument_specs:
         description:
           - "If this is empty, role will download snmp.yml file from U(https://github.com/prometheus/snmp_exporter)."
           - "Otherwise this should contain path to file with custom snmp exporter configuration"
+      snmp_exporter_additional_configs:
+        description:
+          - "List of filepaths to load as configuration files"
+        type: list
+        elements: str
+        default: []
       snmp_exporter_binary_install_dir:
         description:
           - "I(Advanced)"

--- a/roles/snmp_exporter/tasks/preflight.yml
+++ b/roles/snmp_exporter/tasks/preflight.yml
@@ -17,6 +17,13 @@
           snmp_exporter_web_listen_address | type_debug == "list"
         )
 
+- name: Assert that version supports multiple configuration files
+  ansible.builtin.assert:
+    that:
+      - snmp_exporter_version is version('0.26.0', '>=')
+      - snmp_exporter_additional_configs | type_debug == "list"
+  when: snmp_exporter_additional_configs is defined and snmp_exporter_additional_configs | length > 0
+
 - name: Discover latest version
   ansible.builtin.set_fact:
     snmp_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _snmp_exporter_repo }}/releases/latest', headers=_github_api_headers,

--- a/roles/snmp_exporter/templates/snmp_exporter.service.j2
+++ b/roles/snmp_exporter/templates/snmp_exporter.service.j2
@@ -20,6 +20,9 @@ ExecStart={{ snmp_exporter_binary_install_dir }}/snmp_exporter \
 {% else %}
   --web.listen-address={{ snmp_exporter_web_listen_address }} \
 {% endif %}
+{% for config in snmp_exporter_additional_configs %}
+  --config.file={{ config }} \
+{% endfor %}
   --log.level={{ snmp_exporter_log_level }} \
   --config.file={{ snmp_exporter_config_dir }}/snmp.yml
 


### PR DESCRIPTION
Adds support for multiple configuration files. Introduces a seperate variable for the additional files to not break existing configurations.

fixes #212 
