### PR TITLE
feat(snmp_exporter):add support for config.expand-environment-variables flag

### DIFF
--- a/roles/snmp_exporter/defaults/main.yml
+++ b/roles/snmp_exporter/defaults/main.yml
@@ -11,6 +11,7 @@ snmp_exporter_config_file: ""
 
 snmp_exporter_binary_install_dir: "/usr/local/bin"
 snmp_exporter_config_dir: "/etc/snmp_exporter"
+snmp_exporter_expand_environment_variables: false
 
 # Local path to stash the archive and its extraction
 snmp_exporter_local_cache_path: "/tmp/snmp_exporter-{{ ansible_facts['system'] | lower }}-{{ _snmp_exporter_go_ansible_arch }}/{{ snmp_exporter_version }}"

--- a/roles/snmp_exporter/meta/argument_specs.yml
+++ b/roles/snmp_exporter/meta/argument_specs.yml
@@ -48,3 +48,8 @@ argument_specs:
       snmp_exporter_config_dir:
         description: "Path to directory with snmp_exporter configuration"
         default: "/etc/snmp_exporter"
+      snmp_exporter_expand_environment_variables:
+        description:
+          - "allows passing environment variables into some fields of the configuration file."
+          - "The username, password & priv_password fields in the auths section are supported."
+        default: false

--- a/roles/snmp_exporter/templates/snmp_exporter.service.j2
+++ b/roles/snmp_exporter/templates/snmp_exporter.service.j2
@@ -20,6 +20,9 @@ ExecStart={{ snmp_exporter_binary_install_dir }}/snmp_exporter \
 {% else %}
   --web.listen-address={{ snmp_exporter_web_listen_address }} \
 {% endif %}
+{% if snmp_exporter_expand_environment_variables %}
+  --config.expand-environment-variables \
+{% endif %}
   --log.level={{ snmp_exporter_log_level }} \
   --config.file={{ snmp_exporter_config_dir }}/snmp.yml
 


### PR DESCRIPTION
Adds support to enable the [config.expand-environment-variables ](https://github.com/prometheus/snmp_exporter#configuration) flag to be able to pass environment variables from proemtheus directly.
