### PR TITLE
fix: skip process_exporter and systemd_exporter restart handlers in check mode

### DIFF
--- a/roles/process_exporter/handlers/main.yml
+++ b/roles/process_exporter/handlers/main.yml
@@ -6,3 +6,5 @@
     daemon_reload: true
     name: process_exporter
     state: restarted
+  when:
+    - not ansible_check_mode

--- a/roles/systemd_exporter/handlers/main.yml
+++ b/roles/systemd_exporter/handlers/main.yml
@@ -6,3 +6,5 @@
     state: restarted
   become: true
   listen: restart systemd_exporter
+  when:
+    - not ansible_check_mode


### PR DESCRIPTION
## What

Add `when: not ansible_check_mode` to the restart handlers of the `process_exporter` and `systemd_exporter` roles.

## Why

In check mode against a host where the service has never been deployed, the `Create systemd service unit` task reports `changed` but does not actually write the `.service` file, then notifies the restart handler. When handlers flush, the `ansible.builtin.systemd` call with `state: restarted` targets a unit that does not exist, and the run fails:

```
RUNNING HANDLER [prometheus.prometheus.process_exporter : Restart process_exporter]
fatal: [host]: FAILED! => {"changed": false, "msg": "Could not find the requested service process_exporter: host"}
```

This makes `ansible-playbook --check` unusable as a pre-deploy gate on a not-yet-provisioned host.

## Consistency

Every other exporter role already guards its restart handler this way — `node_exporter`, `redis_exporter`, `mysqld_exporter`, `postgres_exporter`, `cadvisor`, and 13 more. Only `process_exporter` and `systemd_exporter` were missed; this PR aligns them with the rest.

```yaml
  when:
    - not ansible_check_mode
```

No functional change outside check mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)