### PR TITLE
fix: node_exporter preflight checks ssl key as ansible user

### DIFF
--- a/roles/node_exporter/tasks/preflight.yml
+++ b/roles/node_exporter/tasks/preflight.yml
@@ -41,6 +41,8 @@
       ansible.builtin.stat:
         path: "{{ node_exporter_tls_server_config.key_file }}"
       register: __node_exporter_key_file
+      become: true
+      become_user: "{{ node_exporter_system_user }}"
 
     - name: Assert that TLS key and cert are present
       ansible.builtin.assert:


### PR DESCRIPTION
The node_exporter TLS certificate private key file may not be readable by the ansible user. The current preflight fails if this is the case. The PR makes the stat call run as the node_exporter_system_user.