### PR TITLE
fix: optionally mask diff output for alertmanager

### DIFF
--- a/roles/alertmanager/defaults/main.yml
+++ b/roles/alertmanager/defaults/main.yml
@@ -146,4 +146,4 @@ alertmanager_local_cache_path: "/tmp/alertmanager-{{ ansible_facts['system'] | l
 alertmanager_system_user: alertmanager
 alertmanager_system_group: "{{ alertmanager_system_user }}"
 
-alert_manager_mask_diff: false
+alertmanager_mask_diff: false

--- a/roles/alertmanager/defaults/main.yml
+++ b/roles/alertmanager/defaults/main.yml
@@ -145,3 +145,5 @@ alertmanager_local_cache_path: "/tmp/alertmanager-{{ ansible_facts['system'] | l
 
 alertmanager_system_user: alertmanager
 alertmanager_system_group: "{{ alertmanager_system_user }}"
+
+alert_manager_mask_diff: false

--- a/roles/alertmanager/meta/argument_specs.yml
+++ b/roles/alertmanager/meta/argument_specs.yml
@@ -122,3 +122,8 @@ argument_specs:
           - "I(Advanced)"
           - "System group for alertmanager"
         default: alertmanager
+      alertmanager_mask_diff:
+        description:
+          - "Switch for preventing output of diff"
+        type: bool
+        default: false

--- a/roles/alertmanager/tasks/configure.yml
+++ b/roles/alertmanager/tasks/configure.yml
@@ -56,7 +56,7 @@
     mode: 0644
     validate: "{{ alertmanager_binary_install_dir }}/amtool check-config %s"
   no_log: "{{ false if (lookup('env', 'CI')) or (lookup('env', 'MOLECULE_PROVISIONER_NAME')) else true }}"
-  diff: "{{ false if alert_manager_mask_diff else true }}"
+  diff: "{{ alert_manager_mask_diff | bool | default(false) }}"
   become: true
   notify:
     - restart alertmanager

--- a/roles/alertmanager/tasks/configure.yml
+++ b/roles/alertmanager/tasks/configure.yml
@@ -56,7 +56,7 @@
     mode: 0644
     validate: "{{ alertmanager_binary_install_dir }}/amtool check-config %s"
   no_log: "{{ false if (lookup('env', 'CI')) or (lookup('env', 'MOLECULE_PROVISIONER_NAME')) else true }}"
-  diff: "{{ alertmanager_mask_diff }}"
+  diff: "{{ not alertmanager_mask_diff }}"
   become: true
   notify:
     - restart alertmanager

--- a/roles/alertmanager/tasks/configure.yml
+++ b/roles/alertmanager/tasks/configure.yml
@@ -56,6 +56,7 @@
     mode: 0644
     validate: "{{ alertmanager_binary_install_dir }}/amtool check-config %s"
   no_log: "{{ false if (lookup('env', 'CI')) or (lookup('env', 'MOLECULE_PROVISIONER_NAME')) else true }}"
+  diff: "{{ false if alert_manager_mask_diff else true }}"
   become: true
   notify:
     - restart alertmanager

--- a/roles/alertmanager/tasks/configure.yml
+++ b/roles/alertmanager/tasks/configure.yml
@@ -56,7 +56,7 @@
     mode: 0644
     validate: "{{ alertmanager_binary_install_dir }}/amtool check-config %s"
   no_log: "{{ false if (lookup('env', 'CI')) or (lookup('env', 'MOLECULE_PROVISIONER_NAME')) else true }}"
-  diff: "{{ alertmanager_mask_diff | bool | default(false) }}"
+  diff: "{{ alertmanager_mask_diff }}"
   become: true
   notify:
     - restart alertmanager

--- a/roles/alertmanager/tasks/configure.yml
+++ b/roles/alertmanager/tasks/configure.yml
@@ -56,7 +56,7 @@
     mode: 0644
     validate: "{{ alertmanager_binary_install_dir }}/amtool check-config %s"
   no_log: "{{ false if (lookup('env', 'CI')) or (lookup('env', 'MOLECULE_PROVISIONER_NAME')) else true }}"
-  diff: "{{ alert_manager_mask_diff | bool | default(false) }}"
+  diff: "{{ alertmanager_mask_diff | bool | default(false) }}"
   become: true
   notify:
     - restart alertmanager


### PR DESCRIPTION
During migration towards [MS Teams v2](https://prometheus.io/docs/alerting/latest/configuration/#msteamsv2_config) we discovered that the webhook URL, that should be treated as a secret, gets printed to log output. This PR adds a simple switch for ansible in [diff mode](https://docs.ansible.com/projects/ansible/latest/playbook_guide/playbooks_checkmode.html#enforcing-or-preventing-diff-mode-on-tasks), one we rely on during dry-runs but should still prevent printing sensitive information