### PR TITLE
feat: install jmx_exporter javaagent role

### DIFF
--- a/roles/jmx_exporter/README.md
+++ b/roles/jmx_exporter/README.md
@@ -1,0 +1,80 @@
+# Ansible Role: jmx exporter
+
+Deploy prometheus [jmx exporter](https://github.com/prometheus/jmx_exporter/tree/main) using ansible.
+
+## Requirements
+
+- gnu-tar on Mac deployer host (`brew install gnu-tar`)
+- Passlib is required when using the basic authentication feature (`python -m pip install passlib bcrypt==4.0.1`)
+
+## Role Variables
+All variables which can be overridden are stored in [defaults/main.yml](defaults/main.yml) file as well as in [meta/argument_specs.yml](meta/argument_specs.yml).
+Please refer to the [collection docs](https://prometheus-community.github.io/ansible/branch/main/jmx_exporter_role.html) for description and default values of the variables.
+
+## Example
+
+### Playbook
+
+Use it in a playbook as follows:
+```yaml
+- hosts: all
+  collections:
+    - prometheus.prometheus
+  roles:
+    - prometheus.prometheus.jmx_exporter
+```
+
+### TLS config
+
+Before running jmx_exporter role, the user needs to provision their own certificate and key.
+```yaml
+- hosts: all
+  pre_tasks:
+    - name: Create jmx_exporter cert dir
+      ansible.builtin.file:
+        path: "/etc/jmx_exporter"
+        state: directory
+        owner: root
+        group: root
+
+    - name: Create cert and key
+      community.crypto.x509_certificate:
+        path: /etc/jmx_exporter/tls.cert
+        csr_path: /etc/jmx_exporter/tls.csr
+        privatekey_path: /etc/jmx_exporter/tls.key
+        provider: selfsigned
+  collections:
+    - prometheus.prometheus
+  roles:
+    - prometheus.prometheus.jmx_exporter
+  vars:
+    jmx_exporter_tls_server_config:
+      cert_file: /etc/jmx_exporter/tls.cert
+      key_file: /etc/jmx_exporter/tls.key
+    jmx_exporter_basic_auth_users:
+      randomuser: examplepassword
+```
+
+### Demo site
+
+We provide an example site that demonstrates a full monitoring solution based on prometheus and grafana. The repository with code and links to running instances is [available on github](https://github.com/prometheus/demo-site) and the site is hosted on [DigitalOcean](https://digitalocean.com).
+
+## Local Testing
+
+The preferred way of locally testing the role is to use Docker and [molecule](https://github.com/ansible-community/molecule) (v3.x). You will have to install Docker on your system. See "Get started" for a Docker package suitable for your system. Running your tests is as simple as executing `molecule test`.
+
+## Continuous Integration
+
+Combining molecule and circle CI allows us to test how new PRs will behave when used with multiple ansible versions and multiple operating systems. This also allows use to create test scenarios for different role configurations. As a result we have quite a large test matrix which can take more time than local testing, so please be patient.
+
+## Contributing
+
+See [contributor guideline](CONTRIBUTING.md).
+
+## Troubleshooting
+
+See [troubleshooting](TROUBLESHOOTING.md).
+
+## License
+
+This project is licensed under MIT License. See [LICENSE](/LICENSE) for more details.

--- a/roles/jmx_exporter/defaults/main.yml
+++ b/roles/jmx_exporter/defaults/main.yml
@@ -5,8 +5,6 @@ jmx_exporter_binary_url: "https://github.com/{{ _jmx_exporter_repo }}/releases/d
 jmx_exporter_checksums_url: "https://github.com/{{ _jmx_exporter_repo }}/releases/download/v{{ jmx_exporter_version }}/jmx_prometheus_javaagent-{{ jmx_exporter_version }}.jar.sha256"
 
 jmx_exporter_web_listen_address: "0.0.0.0:9404"
-jmx_exporter_web_telemetry_path: "/metrics"
-jmx_exporter_timeout_offset: 1
 
 jmx_exporter_tls_server_config: {}
 jmx_exporter_http_server_config: {}

--- a/roles/jmx_exporter/defaults/main.yml
+++ b/roles/jmx_exporter/defaults/main.yml
@@ -10,8 +10,6 @@ jmx_exporter_tls_server_config: {}
 jmx_exporter_http_server_config: {}
 jmx_exporter_basic_auth_users: {}
 
-jmx_exporter_log_level: "error"
-
 jmx_exporter_binary_install_dir: "/usr/local/bin"
 jmx_exporter_system_user: "jmx-exp"
 jmx_exporter_system_group: "{{ jmx_exporter_system_user }}"

--- a/roles/jmx_exporter/defaults/main.yml
+++ b/roles/jmx_exporter/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+jmx_exporter_version: 1.6.0
+jmx_exporter_binary_url: "https://github.com/{{ _jmx_exporter_repo }}/releases/download/v{{ jmx_exporter_version }}/\
+                          jmx_prometheus_javaagent-{{ jmx_exporter_version }}.jar"
+jmx_exporter_checksums_url: "https://github.com/{{ _jmx_exporter_repo }}/releases/download/v{{ jmx_exporter_version }}/jmx_prometheus_javaagent-{{ jmx_exporter_version }}.jar.sha256"
+
+jmx_exporter_web_listen_address: "0.0.0.0:9404"
+jmx_exporter_web_telemetry_path: "/metrics"
+jmx_exporter_timeout_offset: 1
+
+jmx_exporter_tls_server_config: {}
+jmx_exporter_http_server_config: {}
+jmx_exporter_basic_auth_users: {}
+
+jmx_exporter_log_level: "error"
+
+jmx_exporter_binary_install_dir: "/usr/local/bin"
+jmx_exporter_system_user: "jmx-exp"
+jmx_exporter_system_group: "{{ jmx_exporter_system_user }}"
+jmx_exporter_config_dir: "/etc/jmx_exporter"
+jmx_exporter_config_file: "{{ jmx_exporter_config_dir }}/jmx_exporter.yml"
+
+# Local path to stash the archive and its extraction
+jmx_exporter_local_cache_path: "/tmp/jmx_exporter/{{ jmx_exporter_version }}"

--- a/roles/jmx_exporter/handlers/main.yml
+++ b/roles/jmx_exporter/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Restart jmx_exporter
+  listen: "restart jmx_exporter"
+  become: true
+  ansible.builtin.systemd:
+    daemon_reload: true
+    name: jmx_exporter
+    state: restarted
+  when:
+    - not ansible_check_mode

--- a/roles/jmx_exporter/meta/argument_specs.yml
+++ b/roles/jmx_exporter/meta/argument_specs.yml
@@ -1,0 +1,77 @@
+---
+# yamllint disable rule:line-length
+argument_specs:
+  main:
+    short_description: "Prometheus jmx_exporter"
+    description:
+      - "Deploy prometheus L(jmx exporter,https://github.com/prometheus/jmx_exporter) using ansible"
+    author:
+      - "Prometheus Community"
+    options:
+      jmx_exporter_version:
+        description: "jmx_exporter package version. Also accepts latest as parameter."
+        default: "1.6.0"
+      jmx_exporter_binary_url:
+        description: "URL of the jmx_exporter binaries .jar file"
+        default: "https://github.com/{{ _jmx_exporter_repo }}/releases/download/v{{ jmx_exporter_version }}/jmx_prometheus_javaagent-{{ jmx_exporter_version }}.jar"
+      jmx_exporter_checksums_url:
+        description: "URL of the jmx_exporter checksums file"
+        default: "https://github.com/{{ _jmx_exporter_repo }}/releases/download/v{{ jmx_exporter_version }}/jmx_prometheus_javaagent-{{ jmx_exporter_version }}.jar.sha256"
+      jmx_exporter_web_listen_address:
+        description: "Address on which jmx exporter will listen"
+        default: "0.0.0.0:9404"
+      jmx_exporter_web_telemetry_path:
+        description: "Path under which to expose metrics"
+        default: "/metrics"
+      jmx_exporter_uri:
+        description: "URI to scrape jmx metrics"
+        default: "http://localhost/server-status/?auto"
+      jmx_exporter_timeout_offset:
+        description: "Offset to add to the timeout for the scrape"
+        default: 1
+      jmx_exporter_tls_server_config:
+        description:
+          - "Configuration for TLS authentication."
+          - "Keys and values are the same as in L(jmx_exporter docs,https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md)."
+        type: "dict"
+      jmx_exporter_http_server_config:
+        description:
+          - "Config for HTTP/2 support."
+          - "Keys and values are the same as in L(jmx_exporter docs,https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md)."
+        type: "dict"
+      jmx_exporter_basic_auth_users:
+        description: "Dictionary of users and password for basic authentication. Passwords are automatically hashed with bcrypt."
+        type: "dict"
+      jmx_exporter_log_level:
+        description: "Only log messages with the given severity or above. One of: [debug, info, warn, error]"
+        default: "error"
+      jmx_exporter_binary_install_dir:
+        description:
+          - "I(Advanced)"
+          - "Directory to install jmx_exporter binary"
+        default: "/usr/local/bin"
+      jmx_exporter_config_file:
+        description:
+          - "I(Advanced)"
+          - "Path to the JMX Exporter configuration file"
+        default: "/etc/jmx_exporter/jmx_exporter.yml"
+      jmx_exporter_system_user:
+        description:
+          - "I(Advanced)"
+          - "System user for jmx_exporter"
+        default: "jmx-exp"
+      jmx_exporter_system_group:
+        description:
+          - "I(Advanced)"
+          - "System group for jmx_exporter"
+        default: "jmx-exp"
+      jmx_exporter_config_dir:
+        description:
+          - "I(Advanced)"
+          - "Directory to store jmx_exporter configuration"
+        default: "/etc/jmx_exporter"
+      jmx_exporter_local_cache_path:
+        description:
+          - "I(Advanced)"
+          - "Local path to stash the archive and its extraction"
+        default: "/tmp/jmx_exporter-{{ ansible_facts['system'] | lower }}-{{ _jmx_exporter_go_ansible_arch }}/{{ jmx_exporter_version }}"

--- a/roles/jmx_exporter/meta/argument_specs.yml
+++ b/roles/jmx_exporter/meta/argument_specs.yml
@@ -20,15 +20,6 @@ argument_specs:
       jmx_exporter_web_listen_address:
         description: "Address on which jmx exporter will listen"
         default: "0.0.0.0:9404"
-      jmx_exporter_web_telemetry_path:
-        description: "Path under which to expose metrics"
-        default: "/metrics"
-      jmx_exporter_uri:
-        description: "URI to scrape jmx metrics"
-        default: "http://localhost/server-status/?auto"
-      jmx_exporter_timeout_offset:
-        description: "Offset to add to the timeout for the scrape"
-        default: 1
       jmx_exporter_tls_server_config:
         description:
           - "Configuration for TLS authentication."

--- a/roles/jmx_exporter/meta/argument_specs.yml
+++ b/roles/jmx_exporter/meta/argument_specs.yml
@@ -33,9 +33,6 @@ argument_specs:
       jmx_exporter_basic_auth_users:
         description: "Dictionary of users and password for basic authentication. Passwords are automatically hashed with bcrypt."
         type: "dict"
-      jmx_exporter_log_level:
-        description: "Only log messages with the given severity or above. One of: [debug, info, warn, error]"
-        default: "error"
       jmx_exporter_binary_install_dir:
         description:
           - "I(Advanced)"

--- a/roles/jmx_exporter/meta/argument_specs.yml
+++ b/roles/jmx_exporter/meta/argument_specs.yml
@@ -62,4 +62,4 @@ argument_specs:
         description:
           - "I(Advanced)"
           - "Local path to stash the archive and its extraction"
-        default: "/tmp/jmx_exporter-{{ ansible_facts['system'] | lower }}-{{ _jmx_exporter_go_ansible_arch }}/{{ jmx_exporter_version }}"
+        default: "/tmp/jmx_exporter/{{ jmx_exporter_version }}"

--- a/roles/jmx_exporter/meta/main.yml
+++ b/roles/jmx_exporter/meta/main.yml
@@ -1,0 +1,26 @@
+---
+galaxy_info:
+  author: "Prometheus Community"
+  description: "Prometheus jmx_exporter"
+  license: "jmx"
+  min_ansible_version: "2.14"
+  platforms:
+    - name: "Ubuntu"
+      versions:
+        - "jammy"
+        - "noble"
+    - name: "Debian"
+      versions:
+        - "bullseye"
+        - "bookworm"
+    - name: "EL"
+      versions:
+        - "9"
+        - "10"
+  galaxy_tags:
+    - "monitoring"
+    - "prometheus"
+    - "exporter"
+    - "metrics"
+    - "system"
+    - "jmx"

--- a/roles/jmx_exporter/molecule/alternative/molecule.yml
+++ b/roles/jmx_exporter/molecule/alternative/molecule.yml
@@ -1,0 +1,16 @@
+---
+provisioner:
+  playbooks:
+    prepare: "${MOLECULE_PROJECT_DIRECTORY}/../../.config/molecule/alternative/prepare.yml"
+  inventory:
+    group_vars:
+      all:
+        jmx_exporter_web_listen_address: "127.0.0.1:9118"
+        jmx_exporter_tls_server_config:
+          cert_file: /etc/jmx_exporter/tls.cert
+          key_file: /etc/jmx_exporter/tls.key
+        jmx_exporter_http_server_config:
+          http2: true
+        jmx_exporter_basic_auth_users:
+          randomuser: examplepassword
+        jmx_exporter_version: 1.0.8

--- a/roles/jmx_exporter/molecule/alternative/tests/test_alternative.py
+++ b/roles/jmx_exporter/molecule/alternative/tests/test_alternative.py
@@ -1,0 +1,61 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from testinfra_helpers import get_target_hosts
+
+testinfra_hosts = get_target_hosts()
+
+
+def test_directories(host):
+    dirs = [
+        "/etc/jmx_exporter"
+    ]
+    for dir in dirs:
+        d = host.file(dir)
+        assert d.is_directory
+        assert d.exists
+
+
+def test_files(host):
+    files = [
+        "/etc/systemd/system/jmx_exporter.service",
+        "//usr/local/bin/jmx_exporter"
+    ]
+    for file in files:
+        f = host.file(file)
+        assert f.exists
+        assert f.is_file
+
+
+def test_user(host):
+    assert host.group("jmx-exp").exists
+    assert "jmx-exp" in host.user("jmx-exp").groups
+    assert host.user("jmx-exp").shell == "/usr/sbin/nologin"
+
+
+def test_service(host):
+    s = host.service("jmx_exporter")
+    try:
+        assert s.is_running
+    except AssertionError:
+        # Capture service logs
+        journal_output = host.run('journalctl -u jmx_exporter --since "1 hour ago"')
+        print("\n==== journalctl -u jmx_exporter Output ====\n")
+        print(journal_output)
+        print("\n============================================\n")
+        raise  # Re-raise the original assertion error
+
+
+def test_protecthome_property(host):
+    s = host.service("jmx_exporter")
+    p = s.systemd_properties
+    assert p.get("ProtectHome") == "yes"
+
+
+def test_socket(host):
+    sockets = [
+        "tcp://127.0.0.1:9118"
+    ]
+    for socket in sockets:
+        s = host.socket(socket)
+        assert s.is_listening

--- a/roles/jmx_exporter/molecule/default/molecule.yml
+++ b/roles/jmx_exporter/molecule/default/molecule.yml
@@ -1,0 +1,6 @@
+---
+provisioner:
+  inventory:
+    group_vars:
+      all:
+        jmx_exporter_web_listen_address: "127.0.0.1:9117"

--- a/roles/jmx_exporter/molecule/default/tests/test_default.py
+++ b/roles/jmx_exporter/molecule/default/tests/test_default.py
@@ -1,0 +1,61 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from testinfra_helpers import get_target_hosts
+
+testinfra_hosts = get_target_hosts()
+
+
+def test_directories(host):
+    dirs = [
+        "/etc/jmx_exporter"
+    ]
+    for dir in dirs:
+        d = host.file(dir)
+        assert d.is_directory
+        assert d.exists
+
+
+def test_files(host):
+    files = [
+        "/etc/systemd/system/jmx_exporter.service",
+        "//usr/local/bin/jmx_exporter"
+    ]
+    for file in files:
+        f = host.file(file)
+        assert f.exists
+        assert f.is_file
+
+
+def test_user(host):
+    assert host.group("jmx-exp").exists
+    assert "jmx-exp" in host.user("jmx-exp").groups
+    assert host.user("jmx-exp").shell == "/usr/sbin/nologin"
+
+
+def test_service(host):
+    s = host.service("jmx_exporter")
+    try:
+        assert s.is_running
+    except AssertionError:
+        # Capture service logs
+        journal_output = host.run('journalctl -u jmx_exporter --since "1 hour ago"')
+        print("\n==== journalctl -u jmx_exporter Output ====\n")
+        print(journal_output)
+        print("\n============================================\n")
+        raise  # Re-raise the original assertion error
+
+
+def test_protecthome_property(host):
+    s = host.service("jmx_exporter")
+    p = s.systemd_properties
+    assert p.get("ProtectHome") == "yes"
+
+
+def test_socket(host):
+    sockets = [
+        "tcp://127.0.0.1:9117"
+    ]
+    for socket in sockets:
+        s = host.socket(socket)
+        assert s.is_listening

--- a/roles/jmx_exporter/molecule/latest/molecule.yml
+++ b/roles/jmx_exporter/molecule/latest/molecule.yml
@@ -1,0 +1,6 @@
+---
+provisioner:
+  inventory:
+    group_vars:
+      all:
+        jmx_exporter_version: latest

--- a/roles/jmx_exporter/molecule/latest/tests/test_latest.py
+++ b/roles/jmx_exporter/molecule/latest/tests/test_latest.py
@@ -1,0 +1,61 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from testinfra_helpers import get_target_hosts
+
+testinfra_hosts = get_target_hosts()
+
+
+def test_directories(host):
+    dirs = [
+        "/etc/jmx_exporter"
+    ]
+    for dir in dirs:
+        d = host.file(dir)
+        assert d.is_directory
+        assert d.exists
+
+
+def test_files(host):
+    files = [
+        "/etc/systemd/system/jmx_exporter.service",
+        "//usr/local/bin/jmx_exporter"
+    ]
+    for file in files:
+        f = host.file(file)
+        assert f.exists
+        assert f.is_file
+
+
+def test_user(host):
+    assert host.group("jmx-exp").exists
+    assert "jmx-exp" in host.user("jmx-exp").groups
+    assert host.user("jmx-exp").shell == "/usr/sbin/nologin"
+
+
+def test_service(host):
+    s = host.service("jmx_exporter")
+    try:
+        assert s.is_running
+    except AssertionError:
+        # Capture service logs
+        journal_output = host.run('journalctl -u jmx_exporter --since "1 hour ago"')
+        print("\n==== journalctl -u jmx_exporter Output ====\n")
+        print(journal_output)
+        print("\n============================================\n")
+        raise  # Re-raise the original assertion error
+
+
+def test_protecthome_property(host):
+    s = host.service("jmx_exporter")
+    p = s.systemd_properties
+    assert p.get("ProtectHome") == "yes"
+
+
+def test_socket(host):
+    sockets = [
+        "tcp://127.0.0.1:9117"
+    ]
+    for socket in sockets:
+        s = host.socket(socket)
+        assert s.is_listening

--- a/roles/jmx_exporter/tasks/main.yml
+++ b/roles/jmx_exporter/tasks/main.yml
@@ -1,0 +1,105 @@
+---
+- name: Preflight
+  ansible.builtin.include_tasks:
+    file: preflight.yml
+  tags:
+    - jmx_exporter
+    - install
+    - jmx_exporter_install
+    - configure
+    - jmx_exporter_configure
+    - run
+    - jmx_exporter_run
+
+- name: Install
+  ansible.builtin.include_role:
+    name: prometheus.prometheus._common
+    tasks_from: install.yml
+  vars:
+    _common_local_cache_path: "{{ jmx_exporter_local_cache_path }}"
+    _common_binaries: "{{ _jmx_exporter_binaries }}"
+    _common_binary_name: "jmx_exporter.jar"
+    _common_binary_install_dir: "{{ jmx_exporter_binary_install_dir }}"
+    _common_binary_url: "{{ jmx_exporter_binary_url }}"
+    _common_checksums_url: "{{ jmx_exporter_checksums_url }}"
+    _common_system_group: "{{ jmx_exporter_system_group }}"
+    _common_system_user: "{{ jmx_exporter_system_user }}"
+    _common_config_dir: "{{ jmx_exporter_config_dir }}"
+    _common_binary_unarchive_opts: ['--strip-components=1']
+  tags:
+    - jmx_exporter
+    - install
+    - jmx_exporter_install
+
+- name: SELinux
+  ansible.builtin.include_role:
+    name: prometheus.prometheus._common
+    tasks_from: selinux.yml
+  vars:
+    _common_selinux_port: "{{ ('//' ~ jmx_exporter_web_listen_address) | ansible.builtin.urlsplit('port') }}"
+  when: ansible_facts['selinux'].status == "enabled"
+  tags:
+    - jmx_exporter
+    - configure
+    - jmx_exporter_configure
+
+- name: Configure
+  ansible.builtin.include_role:
+    name: prometheus.prometheus._common
+    tasks_from: configure.yml
+  vars:
+    _common_service_name: "jmx_exporter"
+    _common_system_user: "{{ jmx_exporter_system_user }}"
+    _common_system_group: "{{ jmx_exporter_system_group }}"
+    _common_config_dir: "{{ jmx_exporter_config_dir }}"
+    _common_tls_server_config: "{{ jmx_exporter_tls_server_config }}"
+    _common_http_server_config: "{{ jmx_exporter_http_server_config }}"
+    _common_basic_auth_users: "{{ jmx_exporter_basic_auth_users }}"
+  tags:
+    - jmx_exporter
+    - configure
+    - jmx_exporter_configure
+
+- name: Install jmx_exporter wrapper
+  ansible.builtin.template:
+    src: jmx_exporter.sh.j2
+    dest: "{{ jmx_exporter_binary_install_dir }}/jmx_exporter"
+    owner: root
+    group: root
+    mode: 0755
+  become: true
+  notify:
+    - "restart jmx_exporter"
+  tags:
+    - jmx_exporter
+    - install
+    - jmx_exporter_install
+
+- name: Install JMX exporter configuration
+  ansible.builtin.template:
+    src: jmx_exporter.yml.j2
+    dest: "{{ jmx_exporter_config_file }}"
+    owner: "{{ jmx_exporter_system_user }}"
+    group: "{{ jmx_exporter_system_group }}"
+    mode: 0644
+  become: true
+  notify:
+    - "restart jmx_exporter"
+  tags:
+    - jmx_exporter
+    - configure
+    - jmx_exporter_configure
+
+- name: Ensure jmx_exporter is enabled on boot
+  become: true
+  ansible.builtin.systemd:
+    daemon_reload: true
+    name: jmx_exporter
+    enabled: true
+    state: started
+  when:
+    - not ansible_check_mode
+  tags:
+    - jmx_exporter
+    - run
+    - jmx_exporter_run

--- a/roles/jmx_exporter/tasks/preflight.yml
+++ b/roles/jmx_exporter/tasks/preflight.yml
@@ -1,0 +1,55 @@
+---
+- name: Common preflight
+  ansible.builtin.include_role:
+    name: prometheus.prometheus._common
+    tasks_from: preflight.yml
+  vars:
+    _common_web_listen_address: "{{ jmx_exporter_web_listen_address }}"
+
+- name: Assert that used version supports listen address type
+  ansible.builtin.assert:
+    that:
+      - >-
+        jmx_exporter_web_listen_address is string
+
+- name: Assert that TLS config is correct
+  when: jmx_exporter_tls_server_config | length > 0
+  block:
+    - name: Assert that TLS key and cert path are set
+      ansible.builtin.assert:
+        that:
+          - "jmx_exporter_tls_server_config.cert_file is defined"
+          - "jmx_exporter_tls_server_config.key_file is defined"
+
+    - name: Check existence of TLS cert file
+      ansible.builtin.stat:
+        path: "{{ jmx_exporter_tls_server_config.cert_file }}"
+      register: __jmx_exporter_cert_file
+
+    - name: Check existence of TLS key file
+      ansible.builtin.stat:
+        path: "{{ jmx_exporter_tls_server_config.key_file }}"
+      register: __jmx_exporter_key_file
+
+    - name: Assert that TLS key and cert are present
+      ansible.builtin.assert:
+        that:
+          - "__jmx_exporter_cert_file.stat.exists"
+          - "__jmx_exporter_key_file.stat.exists"
+
+- name: Discover latest version
+  ansible.builtin.set_fact:
+    jmx_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _jmx_exporter_repo }}/releases/latest', headers=_github_api_headers,
+                            split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
+  run_once: true
+  until: jmx_exporter_version is version('0.0.0', '>=')
+  retries: 10
+  delay: 10
+  when:
+    - jmx_exporter_version == "latest"
+  tags:
+    - jmx_exporter
+    - install
+    - jmx_exporter_install
+    - download
+    - jmx_exporter_download

--- a/roles/jmx_exporter/templates/apache_exporter.service.j2
+++ b/roles/jmx_exporter/templates/apache_exporter.service.j2
@@ -1,0 +1,35 @@
+{{ ansible_managed | comment }}
+
+[Unit]
+Description=Prometheus jmx Exporter
+Documentation=https://github.com/Lusitaniae/jmx_exporter
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+
+User={{ jmx_exporter_system_user }}
+Group={{ jmx_exporter_system_group }}
+
+ExecStart={{ jmx_exporter_binary_install_dir }}/jmx_exporter
+
+SyslogIdentifier=jmx_exporter
+Restart=always
+RestartSec=1
+StartLimitInterval=0
+
+ProtectHome=yes
+NoNewPrivileges=yes
+
+{% if (ansible_facts.packages.systemd | first).version is version('232', '>=') %}
+ProtectSystem=strict
+ProtectControlGroups=true
+ProtectKernelModules=true
+ProtectKernelTunables=yes
+{% else %}
+ProtectSystem=full
+{% endif %}
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/jmx_exporter/templates/jmx_exporter.service.j2
+++ b/roles/jmx_exporter/templates/jmx_exporter.service.j2
@@ -1,0 +1,35 @@
+{{ ansible_managed | comment }}
+
+[Unit]
+Description=Prometheus jmx Exporter
+Documentation=https://github.com/prometheus/jmx_exporter
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+
+User={{ jmx_exporter_system_user }}
+Group={{ jmx_exporter_system_group }}
+
+ExecStart={{ jmx_exporter_binary_install_dir }}/jmx_exporter
+
+SyslogIdentifier=jmx_exporter
+Restart=always
+RestartSec=1
+StartLimitInterval=0
+
+ProtectHome=yes
+NoNewPrivileges=yes
+
+{% if (ansible_facts.packages.systemd | first).version is version('232', '>=') %}
+ProtectSystem=strict
+ProtectControlGroups=true
+ProtectKernelModules=true
+ProtectKernelTunables=yes
+{% else %}
+ProtectSystem=full
+{% endif %}
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/jmx_exporter/templates/jmx_exporter.sh.j2
+++ b/roles/jmx_exporter/templates/jmx_exporter.sh.j2
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec java -javaagent:{{ jmx_exporter_binary_install_dir }}/jmx_exporter.jar={{ jmx_exporter_web_listen_address | ansible.builtin.urlsplit('port') }}:{{ jmx_exporter_config_file }} "$@"

--- a/roles/jmx_exporter/templates/jmx_exporter.yml.j2
+++ b/roles/jmx_exporter/templates/jmx_exporter.yml.j2
@@ -1,0 +1,4 @@
+---
+startDelaySeconds: 0
+ssl: false
+rules: []

--- a/roles/jmx_exporter/vars/main.yml
+++ b/roles/jmx_exporter/vars/main.yml
@@ -1,0 +1,9 @@
+---
+_jmx_exporter_go_ansible_arch: "{{ {'i386': '386',
+                                  'x86_64': 'amd64',
+                                  'aarch64': 'arm64',
+                                  'armv7l': 'armv7',
+                                  'armv6l': 'armv6'}.get(ansible_facts['architecture'], ansible_facts['architecture']) }}"
+_jmx_exporter_repo: "prometheus/jmx_exporter"
+_github_api_headers: "{{ {'GITHUB_TOKEN': lookup('ansible.builtin.env', 'GITHUB_TOKEN')} if (lookup('ansible.builtin.env', 'GITHUB_TOKEN')) else {} }}"
+_jmx_exporter_binaries: ['jmx_exporter.jar']

--- a/roles/jmx_exporter/vars/main.yml
+++ b/roles/jmx_exporter/vars/main.yml
@@ -1,9 +1,4 @@
 ---
-_jmx_exporter_go_ansible_arch: "{{ {'i386': '386',
-                                  'x86_64': 'amd64',
-                                  'aarch64': 'arm64',
-                                  'armv7l': 'armv7',
-                                  'armv6l': 'armv6'}.get(ansible_facts['architecture'], ansible_facts['architecture']) }}"
 _jmx_exporter_repo: "prometheus/jmx_exporter"
 _github_api_headers: "{{ {'GITHUB_TOKEN': lookup('ansible.builtin.env', 'GITHUB_TOKEN')} if (lookup('ansible.builtin.env', 'GITHUB_TOKEN')) else {} }}"
 _jmx_exporter_binaries: ['jmx_exporter.jar']


### PR DESCRIPTION
## Summary
- install the JMX Exporter Java agent jar from the official release
- add a systemd wrapper and default configuration for the exporter
- wire the role to use the correct service template and config paths

## Testing
- verified the role files and release artifact path locally