### PR TITLE
fix(_common): replace deprecated vars dictionary access

### DIFF
--- a/roles/_common/tasks/preflight.yml
+++ b/roles/_common/tasks/preflight.yml
@@ -11,7 +11,7 @@
 - name: "Check for deprecated skip_install variable"
   ansible.builtin.assert:
     that:
-      - __common_parent_role_short_name ~ '_skip_install' not in vars
+      - query('ansible.builtin.varnames', '^' ~ __common_parent_role_short_name ~ '_skip_install$') | length == 0
     fail_msg: "The variable {{ __common_parent_role_short_name ~ '_skip_install' }} is deprecated.
                Please use `--skip-tags {{ __common_parent_role_short_name }}_install` instead to skip the installation."
   tags:
@@ -22,7 +22,7 @@
 - name: "Check for deprecated binary_local_dir variable"
   ansible.builtin.assert:
     that:
-      - __common_parent_role_short_name ~ '_binary_local_dir' not in vars
+      - query('ansible.builtin.varnames', '^' ~ __common_parent_role_short_name ~ '_binary_local_dir$') | length == 0
     fail_msg: "The variable {{ __common_parent_role_short_name ~ '_binary_local_dir' }} is deprecated.
                Please use the variable {{ __common_parent_role_short_name ~ '_local_cache_path' }} instead"
   tags:
@@ -33,7 +33,7 @@
 - name: "Check for deprecated archive_path variable"
   ansible.builtin.assert:
     that:
-      - __common_parent_role_short_name ~ '_archive_path' not in vars
+      - query('ansible.builtin.varnames', '^' ~ __common_parent_role_short_name ~ '_archive_path$') | length == 0
     fail_msg: "The variable {{ __common_parent_role_short_name ~ '_archive_path' }} is deprecated.
                Please use the variable {{ __common_parent_role_short_name ~ '_local_cache_path' }} instead"
   tags:


### PR DESCRIPTION
## Summary

- Replace direct membership checks against Ansible's internal `vars` dictionary with `ansible.builtin.varnames` lookup.
- Update all three deprecated variable assertions in the `_common` role.
- Preserve detection when deprecated variables are assigned empty values.

  ## Motivation

 ansible-core 2.21 deprecated direct access to its internal `vars` dictionary, for removal in ansible-core 2.24. Currently I'm seeing these deprecation warnings while doing ansible deployments.

This is an alternative to #793 which is stale since April and failing some CI tests.

Using `varnames` avoids an undefined variable error when a variable is absent, and checks variable presence independently of its value.

 Fixes #853 

 ## Validation

 - `ansible-lint` and `yamllint` passed with zero failures or warnings.
 - Verified with ansible-core 2.21.2 that an absent variable passes the assertion, and that an explicitly empty deprecated variable fails it.
 - `git diff --check` passed.