### PR TITLE
fix(prometheus): use ansible_facts for fqdn

### DIFF
--- a/roles/prometheus/defaults/main.yml
+++ b/roles/prometheus/defaults/main.yml
@@ -66,7 +66,7 @@ prometheus_remote_read: []
 #       password: FOO
 
 prometheus_external_labels:
-  environment: "{{ ansible_fqdn | default(ansible_host) | default(inventory_hostname) }}"
+  environment: "{{ ansible_facts['fqdn'] | default(ansible_host) | default(inventory_hostname) }}"
 
 prometheus_targets: {}
 #  node:
@@ -80,7 +80,7 @@ prometheus_scrape_configs:
     metrics_path: "{{ prometheus_metrics_path }}"
     static_configs:
       - targets:
-          - "{{ ansible_fqdn | default(ansible_host) | default('localhost') }}:9090"
+          - "{{ ansible_facts['fqdn'] | default(ansible_host) | default('localhost') }}:9090"
   - job_name: "node"
     file_sd_configs:
       - files:

--- a/roles/prometheus/meta/argument_specs.yml
+++ b/roles/prometheus/meta/argument_specs.yml
@@ -100,7 +100,7 @@ argument_specs:
         description: "Provide map of additional labels which will be added to any time series or alerts when communicating with external systems"
         type: "dict"
         default:
-          environment: "{{ ansible_fqdn | default(ansible_host) | default(inventory_hostname) }}"
+          environment: "{{ ansible_facts['fqdn'] | default(ansible_host) | default(inventory_hostname) }}"
       prometheus_targets:
         description:
           - "Targets which will be scraped."
@@ -115,7 +115,7 @@ argument_specs:
             metrics_path: "{{ prometheus_metrics_path }}"
             static_configs:
               - targets:
-                  - "{{ ansible_fqdn | default(ansible_host) | default('localhost') }}:9090"
+                  - "{{ ansible_facts['fqdn'] | default(ansible_host) | default('localhost') }}:9090"
           - job_name: "node"
             file_sd_configs:
               - files:

--- a/roles/prometheus/molecule/alternative/molecule.yml
+++ b/roles/prometheus/molecule/alternative/molecule.yml
@@ -63,7 +63,7 @@ provisioner:
             metrics_path: "{{ prometheus_metrics_path }}"
             static_configs:
               - targets:
-                  - "{{ ansible_fqdn | default(ansible_host) | default('localhost')\
+                  - "{{ ansible_facts['fqdn'] | default(ansible_host) | default('localhost')\
                     \ }}:9090"
           - job_name: "node"
             file_sd_configs:


### PR DESCRIPTION
## Summary

- Replace injected `ansible_fqdn` references with `ansible_facts['fqdn']`.
- Update the Prometheus defaults and corresponding argument specifications.
- Update the alternative Molecule scenario.
- Preserve the existing `ansible_host`, `inventory_hostname`, and `localhost` fallbacks.

## Motivation

This fixes a deprecation warning I was seeing on my own Ansible deployments. The default behavior of injecting facts as top-level variables is deprecated and will be removed in ansible-core 2.24.

Reading `fqdn` directly from `ansible_facts` avoids the deprecation warning and works when `inject_facts_as_vars` is disabled.

This is a follow-up to #845.

 ## Validation

 - `ansible-lint` and `yamllint` passed with zero failures or warnings.
 - Verified with ansible-core 2.21.2 that the deprecation warning disappears.
 - `git diff --check` passed.