### PR TITLE
fix: Update molecule driver schema

### DIFF
--- a/.config/molecule/config.yml
+++ b/.config/molecule/config.yml
@@ -16,49 +16,41 @@ platforms:
     image: ghcr.io/test-kitchen/dokken/almalinux-9:sha-5a9ecd6
     pre_build_image: true
     privileged: true
-    cgroup_parent: docker.slice
     command: /lib/systemd/systemd
   - name: almalinux-10
     image: ghcr.io/test-kitchen/dokken/almalinux-10:sha-5a9ecd6
     pre_build_image: true
     privileged: true
-    cgroup_parent: docker.slice
     command: /lib/systemd/systemd
   - name: debian-11
     image: ghcr.io/test-kitchen/dokken/debian-11:sha-5a9ecd6
     pre_build_image: true
     privileged: true
-    cgroup_parent: docker.slice
     command: /lib/systemd/systemd
   - name: debian-12
     image: ghcr.io/test-kitchen/dokken/debian-12:sha-5a9ecd6
     pre_build_image: true
     privileged: true
-    cgroup_parent: docker.slice
     command: /lib/systemd/systemd
   - name: debian-13
     image: ghcr.io/test-kitchen/dokken/debian-13:sha-5a9ecd6
     pre_build_image: true
     privileged: true
-    cgroup_parent: docker.slice
     command: /lib/systemd/systemd
   - name: ubuntu-22.04
     image: ghcr.io/test-kitchen/dokken/ubuntu-22.04:sha-5a9ecd6
     pre_build_image: true
     privileged: true
-    cgroup_parent: docker.slice
     command: /lib/systemd/systemd
   - name: ubuntu-24.04
     image: ghcr.io/test-kitchen/dokken/ubuntu-24.04:sha-5a9ecd6
     pre_build_image: true
     privileged: true
-    cgroup_parent: docker.slice
     command: /lib/systemd/systemd
   - name: ubuntu-26.04
     image: ghcr.io/test-kitchen/dokken/ubuntu-26.04:sha-5a9ecd6
     pre_build_image: true
     privileged: true
-    cgroup_parent: docker.slice
     command: /lib/systemd/systemd
 verifier:
   name: testinfra


### PR DESCRIPTION
The `cgroup_parent` key is not allowed in the new molecule-plugins schema check.