### PR TITLE
fix: remove deprecated Ansible templating

### DIFF
--- a/roles/_common/tasks/preflight.yml
+++ b/roles/_common/tasks/preflight.yml
@@ -11,7 +11,7 @@
 - name: "Check for deprecated skip_install variable"
   ansible.builtin.assert:
     that:
-      - __common_parent_role_short_name ~ '_skip_install' not in vars
+      - query('ansible.builtin.varnames', '^' ~ __common_parent_role_short_name ~ '_skip_install$') | length == 0
     fail_msg: "The variable {{ __common_parent_role_short_name ~ '_skip_install' }} is deprecated.
                Please use `--skip-tags {{ __common_parent_role_short_name }}_install` instead to skip the installation."
   tags:
@@ -22,7 +22,7 @@
 - name: "Check for deprecated binary_local_dir variable"
   ansible.builtin.assert:
     that:
-      - __common_parent_role_short_name ~ '_binary_local_dir' not in vars
+      - query('ansible.builtin.varnames', '^' ~ __common_parent_role_short_name ~ '_binary_local_dir$') | length == 0
     fail_msg: "The variable {{ __common_parent_role_short_name ~ '_binary_local_dir' }} is deprecated.
                Please use the variable {{ __common_parent_role_short_name ~ '_local_cache_path' }} instead"
   tags:
@@ -33,7 +33,7 @@
 - name: "Check for deprecated archive_path variable"
   ansible.builtin.assert:
     that:
-      - __common_parent_role_short_name ~ '_archive_path' not in vars
+      - query('ansible.builtin.varnames', '^' ~ __common_parent_role_short_name ~ '_archive_path$') | length == 0
     fail_msg: "The variable {{ __common_parent_role_short_name ~ '_archive_path' }} is deprecated.
                Please use the variable {{ __common_parent_role_short_name ~ '_local_cache_path' }} instead"
   tags:

--- a/roles/alertmanager/tasks/preflight.yml
+++ b/roles/alertmanager/tasks/preflight.yml
@@ -19,7 +19,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    alertmanager_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _alertmanager_repo }}/releases/latest', headers=_github_api_headers,
+    alertmanager_version: "{{ (lookup('url', 'https://api.github.com/repos/' ~ _alertmanager_repo ~ '/releases/latest', headers=_github_api_headers,
                            split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: alertmanager_version is version('0.0.0', '>=')

--- a/roles/apache_exporter/tasks/preflight.yml
+++ b/roles/apache_exporter/tasks/preflight.yml
@@ -39,7 +39,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    apache_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _apache_exporter_repo }}/releases/latest', headers=_github_api_headers,
+    apache_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/' ~ _apache_exporter_repo ~ '/releases/latest', headers=_github_api_headers,
                             split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: apache_exporter_version is version('0.0.0', '>=')

--- a/roles/bind_exporter/tasks/preflight.yml
+++ b/roles/bind_exporter/tasks/preflight.yml
@@ -33,7 +33,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    bind_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _bind_exporter_repo }}/releases/latest', headers=_github_api_headers,
+    bind_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/' ~ _bind_exporter_repo ~ '/releases/latest', headers=_github_api_headers,
                               split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: bind_exporter_version is version('0.0.0', '>=')

--- a/roles/blackbox_exporter/tasks/preflight.yml
+++ b/roles/blackbox_exporter/tasks/preflight.yml
@@ -20,7 +20,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    blackbox_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _blackbox_exporter_repo }}/releases/latest', headers=_github_api_headers,
+    blackbox_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/' ~ _blackbox_exporter_repo ~ '/releases/latest', headers=_github_api_headers,
                                 split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: blackbox_exporter_version is version('0.0.0', '>=')

--- a/roles/cadvisor/tasks/preflight.yml
+++ b/roles/cadvisor/tasks/preflight.yml
@@ -6,7 +6,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    cadvisor_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _cadvisor_repo }}/releases/latest', headers=_github_api_headers,
+    cadvisor_version: "{{ (lookup('url', 'https://api.github.com/repos/' ~ _cadvisor_repo ~ '/releases/latest', headers=_github_api_headers,
                             split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: cadvisor_version is version('0.0.0', '>=')

--- a/roles/chrony_exporter/tasks/preflight.yml
+++ b/roles/chrony_exporter/tasks/preflight.yml
@@ -50,7 +50,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    chrony_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _chrony_exporter_repo }}/releases/latest', headers=_github_api_headers,
+    chrony_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/' ~ _chrony_exporter_repo ~ '/releases/latest', headers=_github_api_headers,
                             split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: chrony_exporter_version is version('0.0.0', '>=')

--- a/roles/consul_exporter/tasks/preflight.yml
+++ b/roles/consul_exporter/tasks/preflight.yml
@@ -41,7 +41,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    consul_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _consul_exporter_repo }}/releases/latest', headers=_github_api_headers,
+    consul_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/' ~ _consul_exporter_repo ~ '/releases/latest', headers=_github_api_headers,
                             split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: consul_exporter_version is version('0.0.0', '>=')

--- a/roles/fail2ban_exporter/tasks/preflight.yml
+++ b/roles/fail2ban_exporter/tasks/preflight.yml
@@ -14,7 +14,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    fail2ban_exporter_version: "{{ (lookup('url', 'https://gitlab.com/api/v4/projects/{{ _fail2ban_exporter_repo }}/releases',
+    fail2ban_exporter_version: "{{ (lookup('url', 'https://gitlab.com/api/v4/projects/' ~ _fail2ban_exporter_repo ~ '/releases',
                                 split_lines=False) | from_json)[0].get('tag_name') | replace('v', '') }}"
   run_once: true
   until: fail2ban_exporter_version is version('0.0.0', '>=')

--- a/roles/influxdb_exporter/tasks/preflight.yml
+++ b/roles/influxdb_exporter/tasks/preflight.yml
@@ -22,7 +22,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    influxdb_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _influxdb_exporter_repo }}/releases/latest', headers=_influxdb_exporter_github_api_headers,
+    influxdb_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/' ~ _influxdb_exporter_repo ~ '/releases/latest', headers=_influxdb_exporter_github_api_headers,
                             split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: influxdb_exporter_version is version('0.0.0', '>=')

--- a/roles/ipmi_exporter/tasks/preflight.yml
+++ b/roles/ipmi_exporter/tasks/preflight.yml
@@ -40,7 +40,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    ipmi_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _ipmi_exporter_repo }}/releases/latest', headers=_github_api_headers,
+    ipmi_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/' ~ _ipmi_exporter_repo ~ '/releases/latest', headers=_github_api_headers,
                             split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: ipmi_exporter_version is version('0.0.0', '>=')

--- a/roles/memcached_exporter/tasks/preflight.yml
+++ b/roles/memcached_exporter/tasks/preflight.yml
@@ -39,7 +39,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    memcached_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _memcached_exporter_repo }}/releases/latest', headers=_github_api_headers,
+    memcached_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/' ~ _memcached_exporter_repo ~ '/releases/latest', headers=_github_api_headers,
                             split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: memcached_exporter_version is version('0.0.0', '>=')

--- a/roles/mongodb_exporter/tasks/preflight.yml
+++ b/roles/mongodb_exporter/tasks/preflight.yml
@@ -39,7 +39,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    mongodb_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _mongodb_exporter_repo }}/releases/latest', headers=_github_api_headers,
+    mongodb_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/' ~ _mongodb_exporter_repo ~ '/releases/latest', headers=_github_api_headers,
                             split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: mongodb_exporter_version is version('0.0.0', '>=')

--- a/roles/mysqld_exporter/tasks/preflight.yml
+++ b/roles/mysqld_exporter/tasks/preflight.yml
@@ -50,7 +50,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    mysqld_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _mysqld_exporter_repo }}/releases/latest', headers=_github_api_headers,
+    mysqld_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/' ~ _mysqld_exporter_repo ~ '/releases/latest', headers=_github_api_headers,
                               split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: mysqld_exporter_version is version('0.0.0', '>=')

--- a/roles/nginx_exporter/tasks/preflight.yml
+++ b/roles/nginx_exporter/tasks/preflight.yml
@@ -39,7 +39,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    nginx_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _nginx_exporter_repo }}/releases/latest', headers=_github_api_headers,
+    nginx_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/' ~ _nginx_exporter_repo ~ '/releases/latest', headers=_github_api_headers,
                             split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: nginx_exporter_version is version('0.0.0', '>=')

--- a/roles/node_exporter/tasks/preflight.yml
+++ b/roles/node_exporter/tasks/preflight.yml
@@ -50,7 +50,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    node_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _node_exporter_repo }}/releases/latest', headers=_github_api_headers,
+    node_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/' ~ _node_exporter_repo ~ '/releases/latest', headers=_github_api_headers,
                             split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: node_exporter_version is version('0.0.0', '>=')

--- a/roles/nvidia_gpu_exporter/tasks/preflight.yml
+++ b/roles/nvidia_gpu_exporter/tasks/preflight.yml
@@ -8,7 +8,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    nvidia_gpu_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _nvidia_gpu_exporter_repo }}/releases/latest',
+    nvidia_gpu_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/' ~ _nvidia_gpu_exporter_repo ~ '/releases/latest',
                                   headers=_nvidia_gpu_exporter_github_api_headers, split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: nvidia_gpu_exporter_version is version('0.0.0', '>=')

--- a/roles/postgres_exporter/tasks/preflight.yml
+++ b/roles/postgres_exporter/tasks/preflight.yml
@@ -50,7 +50,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    postgres_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _postgres_exporter_repo }}/releases/latest', headers=_github_api_headers,
+    postgres_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/' ~ _postgres_exporter_repo ~ '/releases/latest', headers=_github_api_headers,
                               split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: postgres_exporter_version is version('0.0.0', '>=')

--- a/roles/process_exporter/tasks/preflight.yml
+++ b/roles/process_exporter/tasks/preflight.yml
@@ -8,7 +8,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    process_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _process_exporter_repo }}/releases/latest', headers=_github_api_headers,
+    process_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/' ~ _process_exporter_repo ~ '/releases/latest', headers=_github_api_headers,
                             split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: process_exporter_version is version('0.0.0', '>=')

--- a/roles/prometheus/tasks/preflight.yml
+++ b/roles/prometheus/tasks/preflight.yml
@@ -78,7 +78,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    prometheus_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _prometheus_repo}}/releases/latest', headers=_github_api_headers,
+    prometheus_version: "{{ (lookup('url', 'https://api.github.com/repos/' ~ _prometheus_repo ~ '/releases/latest', headers=_github_api_headers,
                          split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: prometheus_version is version('0.0.0', '>=')

--- a/roles/pushgateway/tasks/preflight.yml
+++ b/roles/pushgateway/tasks/preflight.yml
@@ -44,7 +44,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    pushgateway_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _pushgateway_repo }}/releases/latest', headers=_github_api_headers,
+    pushgateway_version: "{{ (lookup('url', 'https://api.github.com/repos/' ~ _pushgateway_repo ~ '/releases/latest', headers=_github_api_headers,
                             split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: pushgateway_version is version('0.0.0', '>=')

--- a/roles/redis_exporter/tasks/preflight.yml
+++ b/roles/redis_exporter/tasks/preflight.yml
@@ -41,7 +41,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    redis_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _redis_exporter_repo }}/releases/latest', headers=_github_api_headers,
+    redis_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/' ~ _redis_exporter_repo ~ '/releases/latest', headers=_github_api_headers,
                             split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: redis_exporter_version is version('0.0.0', '>=')

--- a/roles/smartctl_exporter/tasks/preflight.yml
+++ b/roles/smartctl_exporter/tasks/preflight.yml
@@ -39,7 +39,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    smartctl_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _smartctl_exporter_repo }}/releases/latest', headers=_github_api_headers,
+    smartctl_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/' ~ _smartctl_exporter_repo ~ '/releases/latest', headers=_github_api_headers,
                             split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: smartctl_exporter_version is version('0.0.0', '>=')

--- a/roles/smokeping_prober/tasks/preflight.yml
+++ b/roles/smokeping_prober/tasks/preflight.yml
@@ -44,7 +44,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    smokeping_prober_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _smokeping_prober_repo }}/releases/latest', headers=_github_api_headers,
+    smokeping_prober_version: "{{ (lookup('url', 'https://api.github.com/repos/' ~ _smokeping_prober_repo ~ '/releases/latest', headers=_github_api_headers,
                               split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: smokeping_prober_version is version('0.0.0', '>=')

--- a/roles/snmp_exporter/tasks/preflight.yml
+++ b/roles/snmp_exporter/tasks/preflight.yml
@@ -19,7 +19,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    snmp_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _snmp_exporter_repo }}/releases/latest', headers=_github_api_headers,
+    snmp_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/' ~ _snmp_exporter_repo ~ '/releases/latest', headers=_github_api_headers,
                             split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: snmp_exporter_version is version('0.0.0', '>=')

--- a/roles/systemd_exporter/tasks/preflight.yml
+++ b/roles/systemd_exporter/tasks/preflight.yml
@@ -56,7 +56,7 @@
 
 - name: Discover latest version
   ansible.builtin.set_fact:
-    systemd_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/{{ _systemd_exporter_repo }}/releases/latest',
+    systemd_exporter_version: "{{ (lookup('url', 'https://api.github.com/repos/' ~ _systemd_exporter_repo ~ '/releases/latest',
                                headers=_github_api_headers, split_lines=False) | from_json).get('tag_name') | replace('v', '') }}"
   run_once: true
   until: systemd_exporter_version is version('0.0.0', '>=')


### PR DESCRIPTION
## Summary

- replace deprecated access to Ansible's internal `vars` dictionary with exact `ansible.builtin.varnames` queries
- construct release API URLs with inline Jinja expressions instead of embedded templates
- apply the URL fix consistently across all exporter and Prometheus roles

## Before

With ansible-core 2.21.3, the collection emits these warnings:

```text
[DEPRECATION WARNING]: The internal "vars" dictionary is deprecated.
This feature will be removed from ansible-core version 2.24.
Origin: roles/_common/tasks/preflight.yml:14:9

Use the `vars` and `varnames` lookups instead.
```

```text
[WARNING]: Jinja constant strings should not contain embedded templates.
This feature will be disabled by default in ansible-core 2.23.
Origin: roles/node_exporter/tasks/preflight.yml:53:28

Use inline expressions instead.
```

The first warning occurs in three shared preflight checks. The second pattern
occurs in the latest-version lookup of all 25 public roles.

## Testing

- `ansible-lint`
- `yamllint roles`
- verified the common preflight succeeds without deprecated variables when `ANSIBLE_ALLOW_EMBEDDED_TEMPLATES=false`
- verified all three deprecated variable checks still reject variables whose value is `false`
