### PR TITLE
Fix indentation of collector arguments in node_exporter systemd unit

### DIFF
--- a/roles/node_exporter/templates/node_exporter.service.j2
+++ b/roles/node_exporter/templates/node_exporter.service.j2
@@ -10,17 +10,17 @@ Type=simple
 User={{ node_exporter_system_user }}
 Group={{ node_exporter_system_group }}
 ExecStart={{ node_exporter_binary_install_dir }}/node_exporter \
-{% for collector in node_exporter_enabled_collectors -%}
-{%   if not collector is mapping %}
-    '--collector.{{ collector }}' \
-{%   else -%}
-{%     set name, options = (collector.items()|list)[0] -%}
+{% for collector in node_exporter_enabled_collectors %}
+{%   if collector is mapping %}
+{%     set name, options = (collector.items() | list)[0] %}
     '--collector.{{ name }}' \
-{%     for k,v in options|dictsort %}
+{%     for k, v in options | dictsort %}
     '--collector.{{ name }}.{{ k }}={{ v }}' \
-{%     endfor -%}
-{%   endif -%}
-{% endfor -%}
+{%     endfor %}
+{%   else %}
+    '--collector.{{ collector }}' \
+{%   endif %}
+{% endfor %}
 {% for collector in node_exporter_disabled_collectors %}
     '--no-collector.{{ collector }}' \
 {% endfor %}


### PR DESCRIPTION
Fixes #886

### Changes

- Restructured the Jinja2 loop that emits collector flags so that every argument is emitted with a consistent 4-space indent.
- Simplified the if collector is mapping / else conditions and removed the problematic whitespace-control markers that caused the first line of a mapping collector to lose its indentation.

### Before

```ini
ExecStart=/usr/local/bin/node_exporter \
    '--collector.systemd' \
'--collector.textfile' \
    '--collector.textfile.directory=/var/lib/node_exporter' \
'--collector.filesystem' \
    '--collector.filesystem.ignored-fs-types=^(sys|proc|auto)fs$' \
    '--collector.filesystem.ignored-mount-points=^/(sys|proc|dev)($|/)' \
    '--web.listen-address=0.0.0.0:9100' \
    '--web.telemetry-path=/metrics'
```

### After

```ini
ExecStart=/usr/local/bin/node_exporter \
    '--collector.systemd' \
    '--collector.textfile' \
    '--collector.textfile.directory=/var/lib/node_exporter' \
    '--collector.filesystem' \
    '--collector.filesystem.ignored-fs-types=^(sys|proc|auto)fs$' \
    '--collector.filesystem.ignored-mount-points=^/(sys|proc|dev)($|/)' \
    '--web.listen-address=0.0.0.0:9100' \
    '--web.telemetry-path=/metrics'
```